### PR TITLE
Fix for issue 20, if condition bug in ModifyTableSchema method

### DIFF
--- a/Microsoft.HBase.Client/HBaseClient.cs
+++ b/Microsoft.HBase.Client/HBaseClient.cs
@@ -570,7 +570,7 @@ namespace Microsoft.HBase.Client
                 {
                     using (HttpWebResponse webResponse = await PostRequestAsync(table + "/schema", schema, alternativeEndpointBase))
                     {
-                        if (webResponse.StatusCode != HttpStatusCode.OK || webResponse.StatusCode != HttpStatusCode.Created)
+                        if (webResponse.StatusCode != HttpStatusCode.OK && webResponse.StatusCode != HttpStatusCode.Created)
                         {
                             using (var output = new StreamReader(webResponse.GetResponseStream()))
                             {


### PR DESCRIPTION
Bug in if condition of ModifyTableSchemaInternalAsync method 
  https://github.com/hdinsight/hbase-sdk-for-net/issues/20
The check should exclude HttpStatusCodes OK && Created, instead of OK || Created.
