### PR TITLE
Fixed a bug: now if a string field is empty, it will not crash when converting to base64

### DIFF
--- a/Microsoft.HBase.Client/Entity/Annotations/AbstractColumnSchemaAttribute.cs
+++ b/Microsoft.HBase.Client/Entity/Annotations/AbstractColumnSchemaAttribute.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+
+namespace Microsoft.HBase.Client.Entity.Annotations
+{
+    public enum ColumnEncodingOption
+    {
+        /// <summary>
+        /// this option, row key will only call Bytes.ToBytes to get the byte array
+        /// sortable, easy access raw data. but: not friendly with rest api, eg, int value 1 will be stored as 0x00000001, no way you can use a string to access the data
+        /// </summary>
+        RawBytes = 0,
+        /// <summary>
+        /// this option, row key will get the hex format string of the Bytes.ToBytes, then store the string as Bytes again
+        /// sortable, soso access raw data, rest api friendly, but longer
+        /// </summary>
+        HexString,
+        /// <summary>
+        /// this option, raw key will get the Bytes.ToBytes and then Base64 get the string, then store the string as Bytes again
+        /// not sortable, hard access raw data, rest api friendly, shorter than HexString
+        /// </summary>
+        RawBase64String,
+        /// <summary>
+        /// RawBase64String, then escape / to _ to make rest api friendly
+        /// </summary>
+        SlashEscapedBase64String,
+
+        /// <summary>
+        /// UDT, convert to Json string then to bytes
+        /// </summary>
+        UDTConvertToJson
+    }
+
+    public abstract class AbstractColumnSchemaAttribute : Attribute
+    {
+        public AbstractColumnSchemaAttribute(string columnFamily)
+            : this(columnFamily, string.Empty)
+        {
+
+        }
+        public AbstractColumnSchemaAttribute(string columnFamily, string columnQualifier)
+        {
+            ValidateName(columnFamily);
+            ColumnFamily = columnFamily;
+
+            if (!string.IsNullOrEmpty(columnQualifier))
+            {
+                ValidateName(columnQualifier);
+                ColumnQualifier = columnQualifier;
+            }
+        }
+
+        private static readonly Regex nameRule = new Regex("[a-z][0-9a-z]*", RegexOptions.IgnoreCase);
+
+        public ColumnEncodingOption ColumnEncoding { get; set; }
+        public string ColumnFamily { get; private set; }
+        public string ColumnQualifier { get; private set; }
+        protected void ValidateName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentNullException("name");
+
+            if (!nameRule.IsMatch(name))
+                throw new ArgumentOutOfRangeException("name");
+        }
+
+        public byte[] GetColumnBytes(object value)
+        {
+            return GetColumnBytes(value, ColumnEncoding);
+        }
+
+        public object GetColumnObject(byte[] bytes, Type t)
+        {
+            return GetColumnObject(bytes, t, ColumnEncoding);
+        }
+
+        public static byte[] GetColumnBytes(object value, ColumnEncodingOption encodingOption)
+        {
+            var bytes = Bytes.ToBytes(value);
+
+            switch (encodingOption)
+            {
+                case ColumnEncodingOption.RawBytes:
+                    return bytes;
+                case ColumnEncodingOption.HexString:
+                    return Bytes.ToBytes(Bytes.BytesToHexString(bytes));
+                case ColumnEncodingOption.RawBase64String:
+                    return Bytes.ToBytes(Bytes.BytesToBase64(bytes));
+                case ColumnEncodingOption.SlashEscapedBase64String:
+                    return Bytes.ToBytes(Bytes.BytesToBase64(bytes).Replace('/', '_'));
+                case ColumnEncodingOption.UDTConvertToJson:
+                    return Bytes.ToBytes(JsonConvert.SerializeObject(value));
+                default:
+                    throw new NotImplementedException();
+            }
+
+        }
+
+        public static object GetColumnObject(byte[] bytes, Type t, ColumnEncodingOption encodingOption)
+        {
+            var rawBytes = default(byte[]);
+
+            switch (encodingOption)
+            {
+                case ColumnEncodingOption.RawBytes:
+                    rawBytes = bytes;
+                    break;
+                case ColumnEncodingOption.HexString:
+                    rawBytes = Bytes.HexStringToBytes(Bytes.ToString(bytes));
+                    break;
+                case ColumnEncodingOption.RawBase64String:
+                    rawBytes = Bytes.Base64ToBytes(Bytes.ToString(bytes));
+                    break;
+                case ColumnEncodingOption.SlashEscapedBase64String:
+                    rawBytes = Bytes.Base64ToBytes(Bytes.ToString(bytes).Replace('_', '/'));
+                    break;
+                case ColumnEncodingOption.UDTConvertToJson:
+                    return JsonConvert.DeserializeObject(Bytes.ToString(bytes), t);
+                default:
+                    throw new NotImplementedException();
+            }
+
+            return Bytes.ToObject(rawBytes, t);
+        }
+
+    }
+}

--- a/Microsoft.HBase.Client/Entity/Annotations/ColumnSchemaAttributes.cs
+++ b/Microsoft.HBase.Client/Entity/Annotations/ColumnSchemaAttributes.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.HBase.Client.Entity.Annotations
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class RowKeyAttribute : AbstractColumnSchemaAttribute
+    {
+        public RowKeyAttribute()
+            : base("rowkey")
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class SingleColumnQualifierSchemaAttribute : AbstractColumnSchemaAttribute
+    {
+        public SingleColumnQualifierSchemaAttribute(string columnFamily, string columnQualifier)
+            : base(columnFamily, columnQualifier)
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class DictionaryKeyAsColumnQualifierColumnSchemaAttribute : AbstractColumnSchemaAttribute
+    {
+        public DictionaryKeyAsColumnQualifierColumnSchemaAttribute(string columnFamily)
+            : base(columnFamily)
+        {
+        }
+
+        public const string TIMESTAMPPREFIX = "__ts__";
+        public const string SYSTEMRESERVEDTIMESTAMPQUALIFIER = "__SyStTmReSeRvEd__DiCtIoNaRy__TiMeStAmP__cOlUmNqUaLiFiEr__";
+        public bool VersionControl { get; set; }
+    }
+}

--- a/Microsoft.HBase.Client/Entity/Bytes.cs
+++ b/Microsoft.HBase.Client/Entity/Bytes.cs
@@ -1,0 +1,364 @@
+﻿
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.HBase.Client.Entity
+{
+    public enum HBaseDataTypes
+    {
+        TypeUNKNOWN = 0x0,
+        TypeString,
+        TypeBoolean,
+        TypeLong,
+        TypeInt,
+        TypeFloat,
+        TypeDouble,
+        TypeDateTime,
+        TypeBinary
+    }
+    /// <summary>
+    /// http://grepcode.com/file/repository.cloudera.com/content/repositories/releases/com.cloudera.hbase/hbase/0.89.20100924-28/org/apache/hadoop/hbase/util/Bytes.java
+    /// </summary>
+    public static class Bytes
+    {
+
+        public const int SIZEOF_BOOLEAN = sizeof(bool);
+        public const int SIZEOF_BYTE = sizeof(byte);
+        public const int SIZEOF_CHAR = sizeof(char);
+        public const int SIZEOF_DOUBLE = sizeof(double);
+        public const int SIZEOF_FLOAT = sizeof(float);
+        public const int SIZEOF_INT = sizeof(int);
+        public const int SIZEOF_LONG = sizeof(long);
+
+        public static string ToString(byte[] bytes)
+        {
+            if (bytes == null || bytes.Length == 0)
+                return string.Empty;
+
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        public static bool ToBoolean(byte[] bytes)
+        {
+            if (bytes.Length != SIZEOF_BOOLEAN)
+                throw new ArgumentOutOfRangeException();
+
+            return bytes[0] != (byte)0x0;
+        }
+
+        public static long ToLong(byte[] bytes)
+        {
+            if (bytes.Length != SIZEOF_LONG)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            long l = 0;
+            for (var i = 0; i < SIZEOF_LONG; i++)
+            {
+                l <<= 8;
+                l ^= bytes[i] & 0xFF;
+            }
+
+            return l;
+        }
+
+        public static int ToInt(byte[] bytes)
+        {
+            if (bytes.Length != SIZEOF_INT)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            int n = 0;
+            for (var i = 0; i < SIZEOF_INT; i++)
+            {
+                n <<= 8;
+                n ^= bytes[i] & 0xFF;
+            }
+
+            return n;
+        }
+
+        public static float ToFloat(byte[] bytes)
+        {
+            return IntBitsToFloat(ToInt(bytes));
+        }
+
+        public static double ToDouble(byte[] bytes)
+        {
+            return LongBitsToDouble(ToLong(bytes));
+        }
+
+        public static DateTime ToDateTime(byte[] bytes)
+        {
+            return ToDateTime(ToLong(bytes));
+        }
+
+        public static DateTime ToDateTime(long timestamp)
+        {
+            return new DateTime(1970, 1, 1).AddMilliseconds(timestamp);
+        }
+
+        public static bool IsSupportedType(Type t)
+        {
+            if (t == null)
+                throw new ArgumentNullException();
+
+            return supportedTypesMapping.ContainsKey(t);
+        }
+
+        public static object ToObject(byte[] bytes, Type t)
+        {
+            var ht = HBaseDataTypes.TypeUNKNOWN;
+            if (!supportedTypesMapping.TryGetValue(t, out ht))
+                throw new ArgumentOutOfRangeException();
+
+            switch (ht)
+            {
+                case HBaseDataTypes.TypeBinary:
+                    return bytes;
+                case HBaseDataTypes.TypeBoolean:
+                    return ToBoolean(bytes);
+                case HBaseDataTypes.TypeDateTime:
+                    return ToDateTime(bytes);
+                case HBaseDataTypes.TypeDouble:
+                    return ToDouble(bytes);
+                case HBaseDataTypes.TypeFloat:
+                    return ToFloat(bytes);
+                case HBaseDataTypes.TypeInt:
+                    return ToInt(bytes);
+                case HBaseDataTypes.TypeLong:
+                    return ToLong(bytes);
+                case HBaseDataTypes.TypeString:
+                    return ToString(bytes);
+                default:
+                    throw new NotImplementedException();
+            }
+
+        }
+        public static byte[] ToBytes(object o)
+        {
+            if (o == null)
+                return null;
+
+            var t = o.GetType();
+            var ht = HBaseDataTypes.TypeUNKNOWN;
+            if (!supportedTypesMapping.TryGetValue(t, out ht))
+                throw new ArgumentOutOfRangeException();
+
+            switch (ht)
+            {
+                case HBaseDataTypes.TypeBinary:
+                    return (byte[])o;
+                case HBaseDataTypes.TypeBoolean:
+                    return ToBytes((bool)o);
+                case HBaseDataTypes.TypeDateTime:
+                    return ToBytes((DateTime)o);
+                case HBaseDataTypes.TypeDouble:
+                    return ToBytes((double)o);
+                case HBaseDataTypes.TypeFloat:
+                    return ToBytes((float)o);
+                case HBaseDataTypes.TypeInt:
+                    return ToBytes((int)o);
+                case HBaseDataTypes.TypeLong:
+                    return ToBytes((long)o);
+                case HBaseDataTypes.TypeString:
+                    return ToBytes((string)o);
+                default:
+                    throw new NotImplementedException();
+            }
+
+        }
+
+        public static byte[] ToBytes(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return null;
+
+            return Encoding.UTF8.GetBytes(s);
+        }
+
+        public static byte[] ToBytes(bool b)
+        {
+            return new byte[] { b ? (byte)0xFF : (byte)0x0 };
+        }
+
+        public static byte[] ToBytes(long l)
+        {
+            var bs = new byte[SIZEOF_LONG];
+            for (var i = SIZEOF_LONG - 1; i >= 0; i--)
+            {
+                bs[i] = (byte)(l & 0xFFL);
+                l >>= 8;
+            }
+
+            return bs;
+        }
+
+        public static byte[] ToBytes(int n)
+        {
+            var bs = new byte[SIZEOF_INT];
+            for (var i = SIZEOF_INT - 1; i >= 0; i--)
+            {
+                bs[i] = (byte)(n & 0xFF);
+                n >>= 8;
+            }
+
+            return bs;
+        }
+
+        public static byte[] ToBytes(float f)
+        {
+            return ToBytes(FloatToIntBits(f));
+        }
+
+        public static byte[] ToBytes(double d)
+        {
+            return ToBytes(DoubleToLongBits(d));
+        }
+
+        public static byte[] ToBytes(DateTime dt)
+        {
+            return ToBytes(DateTimeToLong(dt));
+        }
+
+        public static long DateTimeToLong(DateTime dt)
+        {
+            return (long)(dt - new DateTime(1970, 1, 1)).TotalMilliseconds;
+        }
+
+        public static string BytesToBase64(byte[] bytes)
+        {
+            return Convert.ToBase64String(bytes);
+        }
+
+        public static byte[] Base64ToBytes(string base64)
+        {
+            return Convert.FromBase64String(base64);
+        }
+
+        public static string BytesToHexString(byte[] bytes)
+        {
+            StringBuilder sb = new StringBuilder(bytes.Length * 2 + 1);
+            foreach (var b in bytes)
+            {
+                sb.AppendFormat("X2", b);
+            }
+
+            return sb.ToString();
+        }
+
+        public static byte[] HexStringToBytes(string hex)
+        {
+            if (string.IsNullOrEmpty(hex))
+            {
+                return null;
+            }
+
+            var len = hex.Length;
+            if (len % 2 != 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            var bytes = new byte[len >> 1];
+            for (var i = 0; i < hex.Length; i += 2)
+            {
+                bytes[i >> 1] = (byte)((GetByteFromChar(hex[i]) << 4) | GetByteFromChar(hex[i + 1]));
+            }
+
+            return bytes;
+        }
+
+        #region Private
+        private static readonly Dictionary<Type, HBaseDataTypes> supportedTypesMapping = new Dictionary<Type, HBaseDataTypes>
+        {
+            {typeof(string), HBaseDataTypes.TypeString},
+            {typeof(bool), HBaseDataTypes.TypeBoolean},
+            {typeof(long), HBaseDataTypes.TypeLong},
+            {typeof(int), HBaseDataTypes.TypeInt},
+            {typeof(double), HBaseDataTypes.TypeDouble},
+            {typeof(float), HBaseDataTypes.TypeFloat},
+            {typeof(DateTime), HBaseDataTypes.TypeDateTime},
+            {typeof(byte[]), HBaseDataTypes.TypeBinary}
+        };
+
+        private const float FLOAT_POSITIVE_INFINITY = 1.0f / 0.0f;
+        private const float FLOAT_NEGATIVE_INFINITY = -1.0f / 0.0f;
+        private const float FLOAT_NAN = 0.0f / 0.0f;
+        private const int FLOAT_POSITIVE_INFINITY_INTBITS = 0x7F800000;
+        private const int FLOAT_NEGATIVE_INFINITY_INTBITS = (0xFF << 24) | 0x800000;
+        private const int FLOAT_NAN_INTBITS = 0x7FC00000;
+
+        private const double DOUBLE_POSITIVE_INFINITY = 1.0d / 0.0d;
+        private const double DOUBLE_NEGATIVE_INFINITY = -1.0d / 0.0d;
+        private const double DOUBLE_NAN = 0.0d / 0.0d;
+        private const long DOUBLE_POSITIVE_INFINITY_LONGBITS = 0x7FF0000000000000L;
+        private const long DOUBLE_NEGATIVE_INFINITY_LONGBITS = (0xFFL << 56) | 0xF0000000000000L;
+        private const long DOUBLE_NAN_LONGBITS = 0x7FF8000000000000L;
+
+        private static float IntBitsToFloat(int n)
+        {
+            if (n == FLOAT_POSITIVE_INFINITY_INTBITS) return FLOAT_POSITIVE_INFINITY;
+            if (n == FLOAT_NEGATIVE_INFINITY_INTBITS) return FLOAT_NEGATIVE_INFINITY;
+            if (n == FLOAT_NAN_INTBITS) return FLOAT_NAN;
+
+            unsafe
+            {
+                return *((float*)&n);
+            }
+        }
+        private static int FloatToIntBits(float f)
+        {
+            if (float.IsPositiveInfinity(f)) return FLOAT_POSITIVE_INFINITY_INTBITS;
+            if (float.IsNegativeInfinity(f)) return FLOAT_NEGATIVE_INFINITY_INTBITS;
+            if (float.IsNaN(f)) return FLOAT_NAN_INTBITS;
+
+            unsafe
+            {
+                return *((int*)&f);
+            }
+        }
+        private static double LongBitsToDouble(long l)
+        {
+            if (l == DOUBLE_POSITIVE_INFINITY_LONGBITS) return DOUBLE_POSITIVE_INFINITY;
+            if (l == DOUBLE_NEGATIVE_INFINITY_LONGBITS) return DOUBLE_NEGATIVE_INFINITY;
+            if (l == DOUBLE_NAN_LONGBITS) return DOUBLE_NAN;
+
+            unsafe
+            {
+                return *((double*)&l);
+            }
+        }
+        private static long DoubleToLongBits(double d)
+        {
+            if (double.IsPositiveInfinity(d)) return DOUBLE_POSITIVE_INFINITY_LONGBITS;
+            if (double.IsNegativeInfinity(d)) return DOUBLE_NEGATIVE_INFINITY_LONGBITS;
+            if (double.IsNaN(d)) return DOUBLE_NAN_LONGBITS;
+
+            unsafe
+            {
+                return *((long*)&d);
+            }
+        }
+
+        private static byte GetByteFromChar(char c)
+        {
+            var val = (int)c;
+            val = (val - (val < 0x3A ? 0x30 : 0x37));
+            if (val < 0x0 || val > 0xF)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            return (byte)val;
+        }
+
+        #endregion
+    }
+}

--- a/Microsoft.HBase.Client/Entity/HBaseTable.cs
+++ b/Microsoft.HBase.Client/Entity/HBaseTable.cs
@@ -1,0 +1,338 @@
+﻿using Microsoft.HBase.Client.Entity.Annotations;
+using org.apache.hadoop.hbase.rest.protobuf.generated;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.HBase.Client.Entity
+{
+    public class HBaseRow
+    {
+    }
+
+
+    public class HBaseTable<T> : IQueryable<T>, IEnumerable<T>, IHBaseTableOperations<T>
+        where T : HBaseRow, new()
+    {
+        public string TableName { get; set; }
+        private HBaseClient client;
+        public HBaseTable(string tableName, ClusterCredentials credentials)
+        {
+            if (string.IsNullOrEmpty(tableName))
+                throw new ArgumentNullException("tableName");
+
+            if (credentials == null)
+                throw new ArgumentNullException("credentials");
+
+            TableName = tableName;
+            client = new HBaseClient(credentials);
+            UpdateRowInfo();
+        }
+
+        #region Private
+
+        private Tuple<PropertyInfo, RowKeyAttribute> rowKeyInfo = null;
+        private Dictionary<string, Dictionary<string, Tuple<PropertyInfo, SingleColumnQualifierSchemaAttribute>>> singleColumnSchemaInfo = new Dictionary<string, Dictionary<string, Tuple<PropertyInfo, SingleColumnQualifierSchemaAttribute>>>();
+        private Dictionary<string, Tuple<PropertyInfo, DictionaryKeyAsColumnQualifierColumnSchemaAttribute>> groupedColumnSchemaInfo = new Dictionary<string, Tuple<PropertyInfo, DictionaryKeyAsColumnQualifierColumnSchemaAttribute>>();
+
+        private void UpdateRowInfo()
+        {
+            // get key
+            // get column family and column
+            // prepare get/set property
+
+            var properties = typeof(T).GetProperties();
+
+            foreach (var p in properties)
+            {
+                var rowKey = p.GetCustomAttribute<RowKeyAttribute>();
+                var singleSchema = p.GetCustomAttribute<SingleColumnQualifierSchemaAttribute>();
+                var dictSchema = p.GetCustomAttribute<DictionaryKeyAsColumnQualifierColumnSchemaAttribute>();
+
+                if (rowKey != null)
+                {
+                    if (rowKeyInfo != null)
+                        throw new ArgumentException("Only one property with RowKey attribute is allowed");
+
+                    if (singleSchema != null || dictSchema != null)
+                        throw new ArgumentException("One property can only be either RowKey or ColumnQualifier");
+
+                    if (!Bytes.IsSupportedType(p.PropertyType))
+                        throw new ArgumentOutOfRangeException("RowKey type not supported");
+
+                    rowKeyInfo = new Tuple<PropertyInfo, RowKeyAttribute>(p, rowKey);
+                }
+                else if (singleSchema != null)
+                {
+                    if (dictSchema != null)
+                        throw new ArgumentException("One property can only be either SingleColumnQualifier or DictionaryKeyAsColumnQualifier");
+
+                    if (groupedColumnSchemaInfo.ContainsKey(singleSchema.ColumnFamily))
+                        throw new ArgumentException("A ColumnFamily can only be SingleColumnQualifier or DictionaryKeyAsColumnQualifier");
+
+                    Dictionary<string, Tuple<PropertyInfo, SingleColumnQualifierSchemaAttribute>> cfs = null;
+
+                    if (!singleColumnSchemaInfo.TryGetValue(singleSchema.ColumnFamily, out cfs))
+                    {
+                        cfs = new Dictionary<string, Tuple<PropertyInfo, SingleColumnQualifierSchemaAttribute>>();
+                        singleColumnSchemaInfo.Add(singleSchema.ColumnFamily, cfs);
+                    }
+
+                    if (cfs.ContainsKey(singleSchema.ColumnQualifier))
+                        throw new ArgumentException("Duplicate column");
+
+                    if (singleSchema.ColumnEncoding != ColumnEncodingOption.UDTConvertToJson && !Bytes.IsSupportedType(p.PropertyType))
+                        throw new ArgumentOutOfRangeException("Column type not supported");
+
+                    cfs.Add(singleSchema.ColumnQualifier, new Tuple<PropertyInfo, SingleColumnQualifierSchemaAttribute>(p, singleSchema));
+
+                }
+                else if (dictSchema != null)
+                {
+                    if (singleColumnSchemaInfo.ContainsKey(dictSchema.ColumnFamily))
+                        throw new ArgumentException("A ColumnFamily can only be fixed or grouped");
+                    if (groupedColumnSchemaInfo.ContainsKey(dictSchema.ColumnFamily))
+                        throw new ArgumentException("Duplicate ColumnFamily");
+                    var pType = p.PropertyType;
+                    if (!pType.IsGenericType || !(pType.GetInterface(typeof(IDictionary<,>).Name) != null || pType.Name == "IDictionary`2"))
+                        throw new ArgumentException("Not a IDictionary generic type");
+                    var args = pType.GetGenericArguments();
+                    if (args.Length != 2)
+                        throw new ArgumentException("Not a IDcitionary generic type");
+
+                    if (!Bytes.IsSupportedType(args[0]))
+                        throw new ArgumentException("Key type is not supported");
+                    if (args[0] != typeof(string))
+                        throw new ArgumentException("Key type should always be string");
+                    if (dictSchema.ColumnEncoding != ColumnEncodingOption.UDTConvertToJson && !Bytes.IsSupportedType(args[1]))
+                        throw new ArgumentException("Value type is not supported");
+
+                    groupedColumnSchemaInfo.Add(dictSchema.ColumnFamily, new Tuple<PropertyInfo, DictionaryKeyAsColumnQualifierColumnSchemaAttribute>(p, dictSchema));
+                }
+                else
+                { }
+            }
+        }
+
+        public CellSet.Row SerializeToRow(T obj)
+        {
+            var row = (HBaseRow)obj;
+
+            var r = new CellSet.Row();
+            r.key = rowKeyInfo.Item2.GetColumnBytes(rowKeyInfo.Item1.GetValue(row));
+            foreach (var kv in singleColumnSchemaInfo)
+            {
+                foreach (var vn in kv.Value)
+                {
+                    r.values.Add(new Cell { column = Bytes.ToBytes(kv.Key + ":" + vn.Key), data = vn.Value.Item2.GetColumnBytes(vn.Value.Item1.GetValue(row)) });
+                }
+            }
+
+            foreach (var kv in groupedColumnSchemaInfo)
+            {
+                var dict = kv.Value.Item1.GetValue(row) as IDictionary;
+                if (dict == null)
+                    continue;
+
+                var timeStamp = DictionaryKeyAsColumnQualifierColumnSchemaAttribute.TIMESTAMPPREFIX + Bytes.ToLong(kv.Value.Item2.VersionControl ? Bytes.ToBytes(DateTime.UtcNow) : Bytes.ToBytes(0L)).ToString("X16");
+                foreach (string key in dict.Keys)
+                {
+                    var k = kv.Value.Item2.VersionControl ? kv.Key + ":" + timeStamp + ":" + key : kv.Key + ":" + key;
+                    r.values.Add(new Cell { column = Bytes.ToBytes(k), data = kv.Value.Item2.GetColumnBytes(dict[key]) });
+                }
+
+                if (kv.Value.Item2.VersionControl)
+                {
+                    r.values.Add(new Cell { column = Bytes.ToBytes(kv.Key + ":" + DictionaryKeyAsColumnQualifierColumnSchemaAttribute.SYSTEMRESERVEDTIMESTAMPQUALIFIER), data = Bytes.ToBytes(timeStamp) });
+                }
+            }
+
+            return r;
+        }
+
+        public T DeserializeToObject(CellSet.Row row)
+        {
+            var t = new T();
+
+            rowKeyInfo.Item1.SetValue(t, rowKeyInfo.Item2.GetColumnObject(row.key, rowKeyInfo.Item1.PropertyType));
+
+            row.values.Select(p =>
+            {
+                var key = Bytes.ToString(p.column);
+                var kIndex = key.IndexOf(':');
+                var cf = key.Substring(0, kIndex);
+                var c = key.Substring(kIndex + 1);
+
+                return new { cf = cf, c = c, v = p.data };
+            }).GroupBy(p => p.cf).ToList().ForEach(p =>
+            {
+                var cf = p.Key;
+                Dictionary<string, Tuple<PropertyInfo, SingleColumnQualifierSchemaAttribute>> cfs = null;
+                Tuple<PropertyInfo, DictionaryKeyAsColumnQualifierColumnSchemaAttribute> groupedPi = null;
+                if (singleColumnSchemaInfo.TryGetValue(cf, out cfs))
+                {
+                    foreach (var c in p)
+                    {
+                        Tuple<PropertyInfo, SingleColumnQualifierSchemaAttribute> pi = null;
+                        if (!cfs.TryGetValue(c.c, out pi))
+                        {
+                            // cannot find the property
+                        }
+
+                        pi.Item1.SetValue(t, pi.Item2.GetColumnObject(c.v, pi.Item1.PropertyType));
+                    }
+                }
+                else if (groupedColumnSchemaInfo.TryGetValue(cf, out groupedPi))
+                {
+                    var valuetype = groupedPi.Item1.PropertyType.GetGenericArguments()[1];
+                    var dict = Activator.CreateInstance(groupedPi.Item1.PropertyType) as IDictionary;
+
+
+                    if (groupedPi.Item2.VersionControl)
+                    {
+                        var ts = p.Where(q => q.c == DictionaryKeyAsColumnQualifierColumnSchemaAttribute.SYSTEMRESERVEDTIMESTAMPQUALIFIER).FirstOrDefault();
+                        var tsString = ts != null ? Bytes.ToString(ts.v) : string.Empty;
+                        if (string.IsNullOrEmpty(tsString))
+                            throw new ArgumentException();
+
+                        foreach (var kv in p.Where(q => q.c.StartsWith(tsString)).ToDictionary(q => q.c.Substring(tsString.Length + 1), q => groupedPi.Item2.GetColumnObject(q.v, valuetype)))
+                        {
+                            dict.Add(kv.Key, kv.Value);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var kv in p.ToDictionary(q => q.c, q => groupedPi.Item2.GetColumnObject(q.v, valuetype)))
+                        {
+                            dict.Add(kv.Key, kv.Value);
+                        }
+                    }
+
+                    groupedPi.Item1.SetValue(t, dict);
+                }
+                else
+                {
+                    // cannot find the column family
+                }
+            });
+
+            return t;
+        }
+        #endregion
+
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type ElementType
+        {
+            get { return typeof(T); }
+        }
+
+        public System.Linq.Expressions.Expression Expression
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IQueryProvider Provider
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public async Task<bool> CreateTableAsync(bool failIfExist, bool updateSchemaIfExist)
+        {
+
+            var tableSchema = new TableSchema();
+            tableSchema.name = TableName;
+            tableSchema.columns.AddRange(singleColumnSchemaInfo.Select(p => p.Key).Select(p => new ColumnSchema { name = p }));
+            tableSchema.columns.AddRange(groupedColumnSchemaInfo.Select(p => p.Key).Select(p => new ColumnSchema { name = p }));
+            var tables = await client.ListTablesAsync();
+            if (tables.name.Contains(TableName))
+            {
+                if (failIfExist)
+                    return false;
+
+                var existSchema = await client.GetTableSchemaAsync(TableName);
+                var missingCF = existSchema.columns.Where(p => tableSchema.columns.SingleOrDefault(q => q.name == p.name) == null).ToArray();
+                if (updateSchemaIfExist)
+                {
+                    if (missingCF.Length != 0)
+                    {
+                        tableSchema.columns.AddRange(missingCF);
+                        await client.ModifyTableSchemaAsync(TableName, tableSchema);
+                    }
+
+                    return true;
+                }
+                else
+                {
+                    return missingCF.Length == 0;
+                }
+            }
+            else
+            {
+                return await client.CreateTableAsync(tableSchema);
+            }
+        }
+
+        public async Task DeleteTableAsync()
+        {
+            await client.DeleteTableAsync(TableName);
+        }
+
+        public async Task InsertOrUpdateAsync(T entity)
+        {
+            var cellset = new CellSet();
+            cellset.rows.Add(SerializeToRow(entity));
+
+            await client.StoreCellsAsync(TableName, cellset);
+        }
+
+        public async Task DeleteAsync(T entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task InsertOrUpdateRangeAsync(IEnumerable<T> entities)
+        {
+            var cellset = new CellSet();
+            cellset.rows.AddRange(entities.Select(p => SerializeToRow(p)));
+
+            await client.StoreCellsAsync(TableName, cellset);
+        }
+
+        public async Task DeleteRangeAsync(IEnumerable<T> entities)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<IEnumerable<T>> RetriveAllData()
+        {
+            List<T> data = new List<T>();
+            var scanner = await client.CreateScannerAsync(TableName, new Scanner { batch = 1000 });
+            var cellset = default(CellSet);
+            while((cellset = await client.ScannerGetNextAsync(scanner)) != null)
+            {
+                foreach(var r in cellset.rows)
+                {
+                    data.Add(DeserializeToObject(r));
+                }
+            }
+
+            await client.DeleteScannerAsync(TableName, scanner);
+
+            return data;
+        }
+    }
+}

--- a/Microsoft.HBase.Client/Entity/IHBaseTableOperations.cs
+++ b/Microsoft.HBase.Client/Entity/IHBaseTableOperations.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.HBase.Client.Entity
+{
+    interface IHBaseTableOperations<T>
+    {
+        Task<bool> CreateTableAsync(bool failIfExist, bool updateSchemaIfExist);
+        Task DeleteTableAsync();
+
+        Task InsertOrUpdateAsync(T entity);
+        Task DeleteAsync(T entity);
+        Task InsertOrUpdateRangeAsync(IEnumerable<T> entities);
+        Task DeleteRangeAsync(IEnumerable<T> entities);
+    }
+}

--- a/Microsoft.HBase.Client/Entity/TestTable.cs
+++ b/Microsoft.HBase.Client/Entity/TestTable.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.HBase.Client.Entity.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.HBase.Client.Entity
+{
+    public class UdtInRow
+    {
+        public string StringProp { get; set; }
+    }
+
+    public class TestRow : HBaseRow
+    {
+        [RowKey(ColumnEncoding = ColumnEncodingOption.SlashEscapedBase64String)]
+        public string Key { get; set; }
+
+        #region RawBytes
+        [SingleColumnQualifierSchema("cfrawbytes", "cqstring", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public string StringPropRawBytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbytes", "cqint", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public int IntPropRawBytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbytes", "cqlong", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public long LongPropRawBytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbytes", "cqfloat", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public float FloatPropRawBytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbytes", "cqdouble", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public double DoublePropRawBytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbytes", "cqbool", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public bool BoolPropRawBytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbytes", "cqdatetime", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public DateTime DateTimePropRawBytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbytes", "cqbinary", ColumnEncoding = ColumnEncodingOption.RawBytes)]
+        public byte[] BinaryPropRawBytes { get; set; }
+        #endregion
+
+        #region RawBase64String
+        [SingleColumnQualifierSchema("cfrawbase64", "cqstring", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public string StringPropBase64Bytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbase64", "cqint", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public int IntPropBase64Bytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbase64", "cqlong", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public long LongPropBase64Bytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbase64", "cqfloat", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public float FloatPropBase64Bytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbase64", "cqdouble", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public double DoublePropBase64Bytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbase64", "cqbool", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public bool BoolPropBase64Bytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbase64", "cqdatetime", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public DateTime DateTimePropBase64Bytes { get; set; }
+        [SingleColumnQualifierSchema("cfrawbase64", "cqbinary", ColumnEncoding = ColumnEncodingOption.RawBase64String)]
+        public byte[] BinaryPropBase64Bytes { get; set; }
+        #endregion
+
+        #region HexString
+        [SingleColumnQualifierSchema("cfhex", "cqstring", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public string StringPropHexString { get; set; }
+        [SingleColumnQualifierSchema("cfhex", "cqint", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public int IntPropHexString { get; set; }
+        [SingleColumnQualifierSchema("cfhex", "cqlong", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public long LongPropHexString { get; set; }
+        [SingleColumnQualifierSchema("cfhex", "cqfloat", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public float FloatPropHexString { get; set; }
+        [SingleColumnQualifierSchema("cfhex", "cqdouble", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public double DoublePropHexString { get; set; }
+        [SingleColumnQualifierSchema("cfhex", "cqbool", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public bool BoolPropHexString { get; set; }
+        [SingleColumnQualifierSchema("cfhex", "cqdatetime", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public DateTime DateTimePropHexString { get; set; }
+        [SingleColumnQualifierSchema("cfhex", "cqbinary", ColumnEncoding = ColumnEncodingOption.HexString)]
+        public byte[] BinaryPropHexString { get; set; }
+        #endregion
+
+
+        #region UDT
+        [SingleColumnQualifierSchema("cfudt", "cqudtsingle", ColumnEncoding = ColumnEncodingOption.UDTConvertToJson)]
+        public UdtInRow UdtProp { get; set; }
+        [SingleColumnQualifierSchema("cfudt", "cqudtlist", ColumnEncoding = ColumnEncodingOption.UDTConvertToJson)]
+        public List<UdtInRow> UdtListProp { get; set; }
+        [SingleColumnQualifierSchema("cfudt", "cqudtdict", ColumnEncoding = ColumnEncodingOption.UDTConvertToJson)]
+        public Dictionary<int, UdtInRow> UdtDictProp { get; set; }
+
+        #endregion
+
+        #region GroupedCF
+        [DictionaryKeyAsColumnQualifierColumnSchema("cfdictwithvc", ColumnEncoding = ColumnEncodingOption.RawBytes, VersionControl = true)]
+        public Dictionary<string, string> DictPropWithVersionControl { get; set; }
+        [DictionaryKeyAsColumnQualifierColumnSchema("cfdictwithoutvc", ColumnEncoding = ColumnEncodingOption.UDTConvertToJson, VersionControl = false)]
+        public Dictionary<string, UdtInRow> DictPropWithoutVersionControl { get; set; }
+
+        #endregion
+    }
+
+}

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -62,6 +62,7 @@ namespace Microsoft.HBase.Client
         /// <param name="scannerInformation">the scan information</param>
         /// <returns>returns true if the scan was deleted, false if the scan not exists. In case of any other error it throws a WebException</returns>
         bool DeleteScanner(string tableName, ScannerInformation scannerInformation);
+
         /// <summary>
         /// Delete a scanner on the server side
         /// </summary>
@@ -69,6 +70,7 @@ namespace Microsoft.HBase.Client
         /// <param name="scannerInformation">the scan information</param>
         /// <returns>returns true if the scan was deleted, false if the scan not exists. In case of any other error it throws a WebException</returns>
         Task<bool> DeleteScannerAsync(string tableName, ScannerInformation scannerInformation);
+
         /// <summary>
         /// Creates a table and/or fully replaces its schema.
         /// </summary>
@@ -231,5 +233,7 @@ namespace Microsoft.HBase.Client
         /// <param name="cells">the cells to insert</param>
         /// <returns>a task that is awaitable, signifying the end of this operation</returns>
         Task StoreCellsAsync(string table, CellSet cells);
+
+
     }
 }

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -56,6 +56,20 @@ namespace Microsoft.HBase.Client
         Task<ScannerInformation> CreateScannerAsync(string tableName, Scanner scannerSettings);
 
         /// <summary>
+        /// Delete a scanner on the server side
+        /// </summary>
+        /// <param name="tableName">the table to scan</param>
+        /// <param name="scannerInformation">the scan information</param>
+        /// <returns>returns true if the scan was deleted, false if the scan not exists. In case of any other error it throws a WebException</returns>
+        bool DeleteScanner(string tableName, ScannerInformation scannerInformation);
+        /// <summary>
+        /// Delete a scanner on the server side
+        /// </summary>
+        /// <param name="tableName">the table to scan</param>
+        /// <param name="scannerInformation">the scan information</param>
+        /// <returns>returns true if the scan was deleted, false if the scan not exists. In case of any other error it throws a WebException</returns>
+        Task<bool> DeleteScannerAsync(string tableName, ScannerInformation scannerInformation);
+        /// <summary>
         /// Creates a table and/or fully replaces its schema.
         /// </summary>
         /// <param name="schema">the schema</param>

--- a/Microsoft.HBase.Client/Internal/DefaultRetryPolicy.cs
+++ b/Microsoft.HBase.Client/Internal/DefaultRetryPolicy.cs
@@ -29,22 +29,22 @@ namespace Microsoft.HBase.Client.Internal
       private readonly TimeSpan _maximumDuration = TimeSpan.FromMinutes(10);
       private readonly TimeSpan _minimumDuration = TimeSpan.FromMinutes(2);
       private readonly TimeSpan _noDelayDuration = TimeSpan.FromMinutes(2);
-      private int _attemptCount;
-      private bool _initialized;
-      private int _nodeCount = 1;
+
+      //private int _attemptCount;
+      //private bool _initialized;
+      //private int _nodeCount = 1;
       private DateTimeOffset _started;
 
       /// <inheritdoc/>
       public bool ShouldRetryAttempt(Exception e)
       {
+          return false;
+          /*
          if (!_initialized)
          {
             Init();
          }
 
-         // Temporary fix that disables retry policy as it doesn't work correctly in common error cases
-         return false;
-         
          _attemptCount++;
 
          DateTimeOffset now = DateTimeOffset.UtcNow;
@@ -72,6 +72,7 @@ namespace Microsoft.HBase.Client.Internal
          }
 
          return !IsFatalException(e);
+           * */
       }
 
       private Exception GetFirstException(Exception e)
@@ -107,7 +108,7 @@ namespace Microsoft.HBase.Client.Internal
       {
          _started = DateTimeOffset.UtcNow;
          // _nodeCount = UnderDevelopmentApi.GetNodeCount();
-         _initialized = true;
+         //_initialized = true;
       }
 
       private bool IsFatalException(Exception e)

--- a/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
+++ b/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
@@ -154,7 +154,7 @@ namespace Microsoft.HBase.Client.LoadBalancing
                     result = parseConfigValue(configuredValueStr);
                 }
             }
-            catch (Exception e)
+            catch
             {
                 Trace.TraceWarning("Failed to configure parameter with key {0}, failling back on default value {1}", configKey, defaultValue);
             }

--- a/Microsoft.HBase.Client/Microsoft.HBase.Client.csproj
+++ b/Microsoft.HBase.Client/Microsoft.HBase.Client.csproj
@@ -24,7 +24,7 @@
     <IntermediateOutputPath>..\obj\debug\$(AssemblyName)\</IntermediateOutputPath>
     <OutputPath>..\bin\debug\$(AssemblyName)</OutputPath>
     <!--<DocumentationFile>..\bin\debug\$(AssemblyName)\$(AssemblyName).XML</DocumentationFile>-->
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Production.FxCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
@@ -35,8 +35,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IntermediateOutputPath>..\obj\release\$(AssemblyName)\</IntermediateOutputPath>
     <OutputPath>..\bin\release\$(AssemblyName)</OutputPath>
     <!--<DocumentationFile>..\bin\release\$(AssemblyName)\$(AssemblyName).XML</DocumentationFile>-->
@@ -44,6 +44,10 @@
     <CodeAnalysisRuleSet>..\Production.FxCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -57,6 +61,12 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Entity\Annotations\AbstractColumnSchemaAttribute.cs" />
+    <Compile Include="Entity\Annotations\ColumnSchemaAttributes.cs" />
+    <Compile Include="Entity\Bytes.cs" />
+    <Compile Include="Entity\HBaseTable.cs" />
+    <Compile Include="Entity\IHBaseTableOperations.cs" />
+    <Compile Include="Entity\TestTable.cs" />
     <Compile Include="Internal\DefaultRetryPolicyFactory.cs" />
     <Compile Include="Exceptions\ArgumentContainsNullException.cs" />
     <Compile Include="Filters\BinaryComparator.cs" />
@@ -136,6 +146,7 @@
       <Link>FxCopCustomDictionary.xml</Link>
     </CodeAnalysisDictionary>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Microsoft.HBase.Client/packages.config
+++ b/Microsoft.HBase.Client/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixed a bug: now if a string field is empty, it will not crash when converting to base64