### PR TITLE
Issue 24: Added Support to other deployments of HBase REST

### DIFF
--- a/Microsoft.HBase.Client/HBaseClient.cs
+++ b/Microsoft.HBase.Client/HBaseClient.cs
@@ -16,6 +16,7 @@
 namespace Microsoft.HBase.Client
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.Contracts;
     using System.IO;
@@ -61,9 +62,20 @@ namespace Microsoft.HBase.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="HBaseClient"/> class.
         /// </summary>
-        /// <param name="credentials">The credentials.</param>
+        /// <param name="numRegionServers"></param>
         public HBaseClient(int numRegionServers)
             : this(null, new DefaultRetryPolicyFactory(), new LoadBalancerRoundRobin(numRegionServers: numRegionServers))
+        {
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HBaseClient"/> class.
+        /// </summary>
+        /// <param name="serverHostNames"></param>
+        /// <param name="port"></param>
+        public HBaseClient(List<string> serverHostNames, int port)
+            : this(null, new DefaultRetryPolicyFactory(), new LoadBalancerRoundRobin(serverHostNames, port))
         {
         }
 

--- a/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
+++ b/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
@@ -49,12 +49,12 @@ namespace Microsoft.HBase.Client.LoadBalancing
                 servers.Add(string.Format("{0}{1}", _workerHostNamePrefix, i));
             }
             
-            InitializeEndpoints(servers);
+            InitializeEndpoints(servers, _workerRestEndpointPort);
         }
 
-        public LoadBalancerRoundRobin(List<string> regionServerHostNames)
+        public LoadBalancerRoundRobin(List<string> regionServerHostNames, int port)
         {
-            InitializeEndpoints(regionServerHostNames);
+            InitializeEndpoints(regionServerHostNames, port);
         }
 
         public Uri GetEndpoint()
@@ -106,7 +106,7 @@ namespace Microsoft.HBase.Client.LoadBalancing
             return chosenEndpoint;
         }
         
-        private void InitializeEndpoints(List<string> regionServerHostNames)
+        private void InitializeEndpoints(List<string> regionServerHostNames, int port)
         {
             Random rnd = new Random();
 
@@ -117,7 +117,7 @@ namespace Microsoft.HBase.Client.LoadBalancing
 
             foreach (var server in regionServerHostNames)
             {
-                var candidate = string.Format("http://{0}:{1}", server, _workerRestEndpointPort);
+                var candidate = string.Format("http://{0}:{1}", server, port);
                 endpointsList.Add(new Uri(candidate));
             }
             


### PR DESCRIPTION
This change exposes a new constructor on HBaseClient that you can inject a server list and port number. This will allow for connecting to HBase instances without needing an app.config setting.
It uses the existing LoadBalancerRoundRobin class.

```C# 
var servers = new List<string>()
            {
                "hbase1.my.corp",
                "hbase2.my.corp",
                "hbase3.my.corp"
            };
var client = new HBaseClient(servers, 20550);
```