### PR TITLE
Fixing vnet connections by adding constructor param to specify domain

### DIFF
--- a/Microsoft.HBase.Client.Tests/VirtualNetworkLoadBalancerTests.cs
+++ b/Microsoft.HBase.Client.Tests/VirtualNetworkLoadBalancerTests.cs
@@ -164,6 +164,22 @@ namespace Microsoft.HBase.Client.Tests
         }
 
         [TestMethod]
+        public void TestLoadBalancerDomainInit()
+        {
+            int numServers = 10;
+            string testDomain = "test.fakedomain.com";
+            var balancer = new LoadBalancerRoundRobin(numServers, testDomain);
+
+            string[] endpoints = balancer._allEndpoints.Select(u => u.ToString()).OrderBy(s => s).ToArray();
+
+            for (int i = 0; i < endpoints.Length; i++)
+            {
+                string expected = string.Format("http://{0}{1}.{2}:{3}/", LoadBalancerRoundRobin._workerHostNamePrefix, i, testDomain, LoadBalancerRoundRobin._workerRestEndpointPort);
+                Assert.AreEqual(expected, endpoints[i]);
+            }
+        }
+
+        [TestMethod]
         public void TestLoadBalancerConcurrency()
         {
             int numServers = 20;

--- a/Microsoft.HBase.Client/HBaseClient.cs
+++ b/Microsoft.HBase.Client/HBaseClient.cs
@@ -61,9 +61,14 @@ namespace Microsoft.HBase.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="HBaseClient"/> class.
         /// </summary>
-        /// <param name="credentials">The credentials.</param>
-        public HBaseClient(int numRegionServers)
-            : this(null, new DefaultRetryPolicyFactory(), new LoadBalancerRoundRobin(numRegionServers: numRegionServers))
+        /// <remarks>
+        /// To find the cluster vnet domain visit:
+        /// https://azure.microsoft.com/en-us/documentation/articles/hdinsight-hbase-provision-vnet/
+        /// </remarks>
+        /// <param name="numRegionServers">The number of region servers in the cluster.</param>
+        /// <param name="clusterDomain">The fully-qualified domain name of the cluster.</param>
+        public HBaseClient(int numRegionServers, string clusterDomain = null)
+            : this(null, new DefaultRetryPolicyFactory(), new LoadBalancerRoundRobin(numRegionServers: numRegionServers, clusterDomain: clusterDomain))
         {
         }
 

--- a/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
+++ b/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
@@ -41,12 +41,14 @@ namespace Microsoft.HBase.Client.LoadBalancing
         internal int _endpointIndex;
         internal object lockObj;
 
-        public LoadBalancerRoundRobin(int numRegionServers = 1)
+        public LoadBalancerRoundRobin(int numRegionServers = 1, string clusterDomain = null)
         {
             var servers = new List<string>();
+            string domainPostfix = string.IsNullOrWhiteSpace(clusterDomain) ? string.Empty : "." + clusterDomain;
+
             for (uint i = 0; i < numRegionServers; i++)
             {
-                servers.Add(string.Format("{0}{1}", _workerHostNamePrefix, i));
+                servers.Add(string.Format("{0}{1}{2}", _workerHostNamePrefix, i, domainPostfix));
             }
             
             InitializeEndpoints(servers);
@@ -154,7 +156,7 @@ namespace Microsoft.HBase.Client.LoadBalancing
                     result = parseConfigValue(configuredValueStr);
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Trace.TraceWarning("Failed to configure parameter with key {0}, failling back on default value {1}", configKey, defaultValue);
             }


### PR DESCRIPTION
When using the constructor intended for use within a vnet by specifying numRegionServers, the load balancer was not using the fully qualified host name which caused name resolution errors in the client. Fixed by adding a new param to specify the vnet domain the cluster is on. Added a unit test to verify the fully qualified name is used, and manually verified on a cluster deployed within a vnet.