### PR TITLE
add delete cell method and expose alternative endpoint to scanner methods

### DIFF
--- a/Microsoft.HBase.Client.Tests/HBaseClientTests.cs
+++ b/Microsoft.HBase.Client.Tests/HBaseClientTests.cs
@@ -109,6 +109,7 @@ namespace Microsoft.HBase.Client.Tests
 
         [TestMethod]
         [TestCategory(TestRunMode.CheckIn)]
+        [ExpectedException(typeof(System.Net.WebException), "The remote server returned an error: (404) Not Found.")]
         public async Task TestCellsDeletion()
         {
             const string testKey = "content";
@@ -122,8 +123,14 @@ namespace Microsoft.HBase.Client.Tests
             row.values.Add(value);
 
             client.StoreCells(_testTableName, set);
-
+            CellSet cell = await client.GetCellsAsync(_testTableName, testKey);
+            // make sure the cell is in the table
+            Assert.AreEqual(Encoding.UTF8.GetString(cell.rows[0].key), testKey);
+            // delete cell
             await client.DeleteCellsAsync(_testTableName, testKey);
+            // get cell again, 404 exception expected
+            await client.GetCellsAsync(_testTableName, testKey);
+
         }
 
         [TestMethod]

--- a/Microsoft.HBase.Client.Tests/HBaseClientTests.cs
+++ b/Microsoft.HBase.Client.Tests/HBaseClientTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.HBase.Client.Tests
             var client = new HBaseClient(_credentials);
 
             // ensure tables from previous tests are cleaned up
-            
+
             TableList tables = client.ListTables();
             foreach (string name in tables.name)
             {
@@ -59,7 +59,7 @@ namespace Microsoft.HBase.Client.Tests
             _testTableSchema = new TableSchema();
             _testTableSchema.name = _testTableName;
             _testTableSchema.columns.Add(new ColumnSchema { name = "d" });
-           
+
             client.CreateTable(_testTableSchema);
         }
 
@@ -103,8 +103,27 @@ namespace Microsoft.HBase.Client.Tests
 
             // full range scan
             var scanSettings = new Scanner { batch = 10 };
-            ScannerInformation scannerInfo = client.CreateScanner(_testTableName, scanSettings);
-            await client.DeleteScannerAsync(scannerInfo.TableName, scannerInfo.ScannerId);
+            ScannerInformation scannerInfo = await client.CreateScannerAsync(_testTableName, scanSettings, "hbaserest0/");
+            await client.DeleteScannerAsync(scannerInfo.TableName, scannerInfo.ScannerId, "hbaserest0/");
+        }
+
+        [TestMethod]
+        [TestCategory(TestRunMode.CheckIn)]
+        public async Task TestCellsDeletion()
+        {
+            const string testKey = "content";
+            const string testValue = "the force is strong in this column";
+            var client = new HBaseClient(_credentials);
+            var set = new CellSet();
+            var row = new CellSet.Row { key = Encoding.UTF8.GetBytes(testKey) };
+            set.rows.Add(row);
+
+            var value = new Cell { column = Encoding.UTF8.GetBytes("d:starwars"), data = Encoding.UTF8.GetBytes(testValue) };
+            row.values.Add(value);
+
+            client.StoreCells(_testTableName, set);
+
+            await client.DeleteCellsAsync(_testTableName, testKey);
         }
 
         [TestMethod]

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -53,14 +53,21 @@ namespace Microsoft.HBase.Client
         /// <param name="tableName">the table to scan</param>
         /// <param name="scannerSettings">the settings to e.g. set the batch size of this scan</param>
         /// <returns>A ScannerInformation which contains the continuation url/token and the table name</returns>
-        Task<ScannerInformation> CreateScannerAsync(string tableName, Scanner scannerSettings);
+        Task<ScannerInformation> CreateScannerAsync(string tableName, Scanner scannerSettings, string alternativeEndpointBase = null);
 
         /// <summary>
         /// Deletes scanner.        
         /// </summary>
         /// <param name="tableName">the table the scanner is associated with.</param>
         /// <param name="scannerId">the id of the scanner to delete.</param>
-        Task DeleteScannerAsync(string tableName, string scannerId);
+        Task DeleteScannerAsync(string tableName, string scannerId, string alternativeEndpointBase = null);
+
+        /// <summary>
+        /// Deletes row with specific row key.        
+        /// </summary>
+        /// <param name="tableName">the table name</param>
+        /// <param name="rowKey">the row to delete</param>
+        Task DeleteCellsAsync(string tableName, string rowKey);
 
         /// <summary>
         /// Creates a table and/or fully replaces its schema.
@@ -208,7 +215,7 @@ namespace Microsoft.HBase.Client
         /// </summary>
         /// <param name="scannerInfo">the scanner information retrieved by #CreateScanner()</param>
         /// <returns>a cellset, or null if the scanner is exhausted</returns>
-        Task<CellSet> ScannerGetNextAsync(ScannerInformation scannerInfo);
+        Task<CellSet> ScannerGetNextAsync(ScannerInformation scannerInfo, string alternativeEndpointBase = null);
 
         /// <summary>
         /// Stores the given cells in the supplied table.


### PR DESCRIPTION
1. add async delete cell with rowkey method
2. expose alternative endpoint to scanner methods, so users can implement load balancing by themselves, simply putting "hbaserestN" as alternative endpoint. The scanner will be created on REST server on workernode N. NOTE: As the scan API is not stateless, create scanner, scan table with scan id and delete scanner should use the same endpoint. By default it is REST server on workernode0 if alternative endpoint is not provided.