### PR TITLE
Added an AlternativeHost field to RequestOptions

### DIFF
--- a/Microsoft.HBase.Client/RequestOptions.cs
+++ b/Microsoft.HBase.Client/RequestOptions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.HBase.Client
         public bool UseNagle { get; set; }
         public int Port { get; set; }
         public Dictionary<string, string> AdditionalHeaders { get; set; }
+        public string AlternativeHost { get; set; }
 
         public void Validate()
         {
@@ -52,7 +53,8 @@ namespace Microsoft.HBase.Client
                 SerializationBufferSize = 1024 * 1024 * 1,
                 UseNagle = false,
                 AlternativeEndpoint = Constants.RestEndpointBase,
-                Port = 443
+                Port = 443,
+                AlternativeHost = null
             };
         }
 

--- a/Microsoft.HBase.Client/Requester/VNetWebRequester.cs
+++ b/Microsoft.HBase.Client/Requester/VNetWebRequester.cs
@@ -71,9 +71,12 @@ namespace Microsoft.HBase.Client.Requester
             Trace.CorrelationManager.ActivityId = Guid.NewGuid();
             var balancedEndpoint = _balancer.GetEndpoint();
 
+            // Grab the host. Use the alternative host if one is specified
+            string host = (options.AlternativeHost != null) ? options.AlternativeHost : balancedEndpoint.Host;
+
             UriBuilder builder = new UriBuilder(
                 balancedEndpoint.Scheme,
-                balancedEndpoint.Host,
+                host,
                 options.Port,
                 options.AlternativeEndpoint + endpoint);
 


### PR DESCRIPTION
Scanner calls with the same id need to be made to the same RegionServer.
The alternative host field enables you to specify the host for scanner
calls as required.

Example Usage:
    RequestOptions options = RequestOptions.GetDefaultOptions();
    scannerInfo = await _hbaseClient.CreateScannerAsync(_tablename, scanSettings, options);
    options.AlternativeHost = scannerInfo.Location.Host;
    _hbaseClient.ScannerGetNextAsync(scannerInfo, options)