### PR TITLE
Fixed "Arithmetic operation resulted in an overflow." error

### DIFF
--- a/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
+++ b/Microsoft.HBase.Client/LoadBalancing/LoadBalancerRoundRobin.cs
@@ -38,7 +38,7 @@ namespace Microsoft.HBase.Client.LoadBalancing
         
         internal Uri[] _allEndpoints;
         internal IEndpointIgnorePolicy _endpointIgnorePolicy;
-        internal int _endpointIndex;
+        internal uint _endpointIndex;
         internal object lockObj;
 
         public LoadBalancerRoundRobin(int numRegionServers = 1, string clusterDomain = null)
@@ -92,6 +92,7 @@ namespace Microsoft.HBase.Client.LoadBalancing
         {
             Uri chosenEndpoint;
             int attemptCounter = 0;
+
             do
             {
                 chosenEndpoint = _allEndpoints[_endpointIndex++ % _allEndpoints.Length];
@@ -115,7 +116,7 @@ namespace Microsoft.HBase.Client.LoadBalancing
             lockObj = new object();
 
             var endpointsList = new List<Uri>();
-            _endpointIndex = rnd.Next();
+            _endpointIndex = (uint) rnd.Next();
 
             foreach (var server in regionServerHostNames)
             {


### PR DESCRIPTION
During normal operation I saw this error come up when running read scans. The variable was an int and can overflow if incremented past max. We start with a random value so it will be arbitrarily close to this max at init time. The value is now a uint so that it will go to 0 and not overflow when incremented past max.