### PR TITLE
Adding CheckAndPut, CheckAndDelete Support 

### DIFF
--- a/Microsoft.HBase.Client.Tests/ScannerInformationTests.cs
+++ b/Microsoft.HBase.Client.Tests/ScannerInformationTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.HBase.Client.Tests
         [TestCategory(TestRunMode.CheckIn)]
         public void It_should_have_the_expected_scanner_identifier()
         {
-            target.ScannerId.ShouldEqual(expectedScannerId);
+            target.ScannerId.ShouldEqual(expectedScannerId.Substring(1));
         }
 
         [TestMethod]

--- a/Microsoft.HBase.Client.Tests/VirtualNetworkLoadBalancerTests.cs
+++ b/Microsoft.HBase.Client.Tests/VirtualNetworkLoadBalancerTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.HBase.Client.Tests
             int numServers = 10;
 
             var balancer = new LoadBalancerRoundRobin(numServers);
-            int initRRIdx = balancer._endpointIndex;
+            uint initRRIdx = balancer._endpointIndex;
 
             for (int i = 0; i < 2 * numServers; i++)
             {

--- a/Microsoft.HBase.Client/Requester/IWebRequester.cs
+++ b/Microsoft.HBase.Client/Requester/IWebRequester.cs
@@ -22,9 +22,9 @@ namespace Microsoft.HBase.Client.Requester
 
     public interface IWebRequester
     {
-        Response IssueWebRequest(string endpoint, string method, Stream input, RequestOptions options);
+        Response IssueWebRequest(string endpoint, string query, string method, Stream input, RequestOptions options);
 
-        Task<Response> IssueWebRequestAsync(string endpoint, string method, Stream input, RequestOptions options);
+        Task<Response> IssueWebRequestAsync(string endpoint, string query, string method, Stream input, RequestOptions options);
     }
 
     public class Response : IDisposable


### PR DESCRIPTION
+ Support for CheckAndPut and CheckAndDelete as per the hbase rest api
+ Fixed unit tests that were failing to compile
+ Moved stream.Seek to the caller instead of the WebRequestor classes
+ Handling the 304 responses as valid responses
+ Accpeting 404 as valid response in case of VNetLoad balancer