### PR TITLE
Delete Cells with a Timestamp Support & CheckAndDelete Enhancements

### DIFF
--- a/Microsoft.HBase.Client.Tests/CellOperationsTests.cs
+++ b/Microsoft.HBase.Client.Tests/CellOperationsTests.cs
@@ -1,0 +1,253 @@
+﻿// Copyright (c) Microsoft Corporation
+// All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+// 
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// 
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace Microsoft.HBase.Client.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using Microsoft.HBase.Client.Filters;
+    using Microsoft.HBase.Client.Tests.Utilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using org.apache.hadoop.hbase.rest.protobuf.generated;
+    using System.Net;
+    using Practices.EnterpriseLibrary.TransientFaultHandling;    // ReSharper disable InconsistentNaming
+    using System.Threading.Tasks;
+    [TestClass]
+    public class CellOperationsTests : DisposableContextSpecification
+    {
+        private const string TableNamePrefix = "celltest";
+
+        private const string ColumnFamilyName1 = "first";
+        private const string ColumnFamilyName2 = "second";
+        private const string ColumnNameA = "a";
+        private const string ColumnNameB = "b";
+
+        private static bool _arrangementCompleted;
+        private static readonly List<FilterTestRecord> _allExpectedRecords = new List<FilterTestRecord>();
+        private static ClusterCredentials _credentials;
+        private static readonly Encoding _encoding = Encoding.UTF8;
+        private static string _tableName;
+        private static TableSchema _tableSchema;
+
+        protected override void Context()
+        {
+            if (!_arrangementCompleted)
+            {
+                _credentials = ClusterCredentialsFactory.CreateFromFile(@".\credentials.txt");
+                var client = new HBaseClient(_credentials);
+
+                // ensure tables from previous tests are cleaned up
+                TableList tables = client.ListTables();
+                foreach (string name in tables.name)
+                {
+                    string pinnedName = name;
+                    if (name.StartsWith(TableNamePrefix, StringComparison.Ordinal))
+                    {
+                        client.DeleteTable(pinnedName);
+                    }
+                }
+
+                AddTable();
+                _arrangementCompleted = true;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TestRunMode.CheckIn)]
+        public void When_I_DeleteCells_With_TimeStamp_I_can_add_with_higher_timestamp()
+        {
+            RequestOptions options = RequestOptions.GetDefaultOptions();
+            options.RetryPolicy = RetryPolicy.NoRetry;
+            var client = new HBaseClient(_credentials, options);
+
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("1", "c1", "1A", 10)));
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("1", "c2", "1A", 10)));
+
+            client.DeleteCells(_tableName, "1", ColumnFamilyName1, 10);
+
+            try
+            {
+                client.GetCells(_tableName, "1");
+                Assert.Fail("Expected to throw an exception as the row is deleted");
+            }
+            catch(Exception ex)
+            {
+                if (ex is AggregateException)
+                {
+                    ((ex.InnerException as WebException).Response as HttpWebResponse).StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+                }
+            }
+
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("1", "c1", "1A", 11)));
+
+            var retrievedCells = client.GetCells(_tableName, "1");
+
+            retrievedCells.rows.Count.ShouldEqual(1);
+            retrievedCells.rows[0].values[0].timestamp.ShouldEqual(11);
+        }
+
+        [TestMethod]
+        [TestCategory(TestRunMode.CheckIn)]
+        public void When_I_DeleteCells_With_TimeStamp_I_cannot_add_with_lower_timestamp()
+        {
+            RequestOptions options = RequestOptions.GetDefaultOptions();
+            options.RetryPolicy = RetryPolicy.NoRetry;
+            var client = new HBaseClient(_credentials, options);
+
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("2", "c1", "1A", 10)));
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("2", "c2", "1A", 10)));
+
+            client.DeleteCells(_tableName, "2", ColumnFamilyName1, 10);
+
+            try
+            {
+                client.GetCells(_tableName, "2");
+                Assert.Fail("Expected to throw an exception as the row is deleted");
+            }
+            catch (Exception ex)
+            {
+                if (ex is AggregateException)
+                {
+                    ((ex.InnerException as WebException).Response as HttpWebResponse).StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+                }
+            }
+
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("2", "c1", "1A", 9)));
+
+            try
+            {
+                client.GetCells(_tableName, "2");
+                Assert.Fail("Expected to throw an exception as the row cannot be added with lower timestamp");
+            }
+            catch (Exception ex)
+            {
+                if (ex is AggregateException)
+                {
+                    ((ex.InnerException as WebException).Response as HttpWebResponse).StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+                }
+            }
+        }
+
+
+        [TestMethod]
+        [TestCategory(TestRunMode.CheckIn)]
+        public async Task When_I_CheckAndDeleteCells_With_TimeStamp_I_cannot_add_with_lower_timestamp_than_hbaseserver()
+        {
+            RequestOptions options = RequestOptions.GetDefaultOptions();
+            options.RetryPolicy = RetryPolicy.NoRetry;
+            var client = new HBaseClient(_credentials, options);
+
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("3", "c1", "1A", 10)));
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("3", "c2", "1A", 10)));
+
+            bool deleted = await client.CheckAndDeleteAsync(_tableName, GetCell("3","c1","1A",10));
+
+            deleted.ShouldEqual(true);
+
+            try
+            {
+                client.GetCells(_tableName, "3");
+                Assert.Fail("Expected to throw an exception as the row is deleted");
+            }
+            catch (Exception ex)
+            {
+                if (ex is AggregateException)
+                {
+                    ((ex.InnerException as WebException).Response as HttpWebResponse).StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+                }
+            }
+
+            client.StoreCells(_tableName, CreateCellSet(GetCellSet("3", "c1", "1B", 11)));
+
+            try
+            {
+                client.GetCells(_tableName, "3");
+                Assert.Fail("Expected to throw an exception as the row cannot be added with lower timestamp than servers timestamp");
+            }
+            catch (Exception ex)
+            {
+                if (ex is AggregateException)
+                {
+                    ((ex.InnerException as WebException).Response as HttpWebResponse).StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+                }
+            }
+        }
+
+
+        private CellSet CreateCellSet(params CellSet.Row[] rows)
+        {
+            CellSet cellSet = new CellSet();
+            cellSet.rows.AddRange(rows);
+            return cellSet;
+        }
+
+        private Cell GetCell(string key, string columnName, string oldValue = null, long timestamp = 0)
+        {
+            Cell cell = new Cell() { column = BuildCellColumn(ColumnFamilyName1, columnName) , row = Encoding.UTF8.GetBytes(key) };
+            if (oldValue != null)
+            {
+                cell.data = Encoding.UTF8.GetBytes(oldValue);
+            }
+            if (timestamp > 0)
+            {
+                cell.timestamp = timestamp;
+            }
+            return cell;
+        }
+        private CellSet.Row GetCellSet(string key, string columnName, string value, long timestamp)
+        {
+            CellSet.Row row = new CellSet.Row() { key = Encoding.UTF8.GetBytes(key) };
+            Cell c1 = new Cell() { column = BuildCellColumn(ColumnFamilyName1, columnName ), row = row.key };
+            if (value != null)
+            {
+                c1.data = Encoding.UTF8.GetBytes(value);
+            }
+
+            if (timestamp > 0)
+            {
+                c1.timestamp = timestamp;
+            }
+            row.values.Add(c1);
+            return row;
+        }
+
+        private Byte[] BuildCellColumn(string columnFamilyName, string columnName)
+        {
+            return _encoding.GetBytes(string.Format(CultureInfo.InvariantCulture, "{0}:{1}", columnFamilyName, columnName));
+        }
+
+        private string ExtractColumnName(Byte[] cellColumn)
+        {
+            string qualifiedColumnName = _encoding.GetString(cellColumn);
+            string[] parts = qualifiedColumnName.Split(new[] { ':' }, 2);
+            return parts[1];
+        }
+
+        private void AddTable()
+        {
+            // add a table specific to this test
+            var client = new HBaseClient(_credentials);
+            _tableName = TableNamePrefix + Guid.NewGuid().ToString("N");
+            _tableSchema = new TableSchema { name = _tableName };
+            _tableSchema.columns.Add(new ColumnSchema { name = ColumnFamilyName1 });
+            _tableSchema.columns.Add(new ColumnSchema { name = ColumnFamilyName2 });
+
+            client.CreateTable(_tableSchema);
+        }
+    }
+}

--- a/Microsoft.HBase.Client.Tests/Microsoft.HBase.Client.Tests.csproj
+++ b/Microsoft.HBase.Client.Tests/Microsoft.HBase.Client.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ClusterCredentialsFactoryTests.cs" />
     <Compile Include="ClusterCredentialsTests.cs" />
     <Compile Include="FilterTestRecord.cs" />
+    <Compile Include="CellOperationsTests.cs" />
     <Compile Include="FilterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Clients\HBaseClientTestBase.cs" />

--- a/Microsoft.HBase.Client/HBaseClient.cs
+++ b/Microsoft.HBase.Client/HBaseClient.cs
@@ -604,9 +604,9 @@ namespace Microsoft.HBase.Client
         /// <param name="table">the table</param>
         /// <param name="cellToCheck">cell to check for deleting the row</param>
         /// <returns>true if the record was deleted; false if condition failed at check</returns>
-        public bool CheckAndDelete(string table, Cell cellToCheck, RequestOptions options = null)
+        public bool CheckAndDelete(string table, Cell cellToCheck, CellSet.Row rowToDelete = null, RequestOptions options = null)
         {
-            Task<bool> t = CheckAndDeleteAsync(table, cellToCheck, options);
+            Task<bool> t = CheckAndDeleteAsync(table, cellToCheck, rowToDelete, options);
             t.Wait();
             return t.Result;
         }
@@ -617,11 +617,21 @@ namespace Microsoft.HBase.Client
         /// <param name="table">the table</param>
         /// <param name="cellToCheck">cell to check for deleting the row</param>
         /// <returns>true if the record was deleted; false if condition failed at check</returns>
-        public async Task<bool> CheckAndDeleteAsync(string table, Cell cellToCheck, RequestOptions options = null)
+        public async Task<bool> CheckAndDeleteAsync(string table, Cell cellToCheck, CellSet.Row rowToDelete = null, RequestOptions options = null)
         {
             table.ArgumentNotNullNorEmpty("table");
             cellToCheck.ArgumentNotNull("cellToCheck");
-            CellSet.Row row = new CellSet.Row() { key = cellToCheck.row }; 
+
+            CellSet.Row row;
+            if (rowToDelete != null)
+            {
+                row = rowToDelete;
+            }
+            else
+            {
+                row = new CellSet.Row() { key = cellToCheck.row };
+            }
+
             row.values.Add(cellToCheck);
             var cellSet = new CellSet();
             cellSet.rows.Add(row);

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -84,6 +84,24 @@ namespace Microsoft.HBase.Client
         Task DeleteCellsAsync(string tableName, string rowKey, RequestOptions options = null);
 
         /// <summary>
+        /// Deletes row with specific row key and specific columnFamily and versions less than the mentioned one  
+        /// </summary>
+        /// <param name="tableName">the table name</param>
+        /// <param name="rowKey">the row to delete</param>
+        /// <param name="columnFamily">the column family to delete</param>
+        /// <param name="timestamp">timestamp's lower than this will be deleted for the row</param>
+        void DeleteCells(string tableName, string rowKey, string columnFamily, long timestamp, RequestOptions options = null);
+
+        /// <summary>
+        /// Deletes row with specific row key and specific columnFamily and versions less than the mentioned one
+        /// </summary>
+        /// <param name="tableName">the table name</param>
+        /// <param name="rowKey">the row to delete</param>
+        /// <param name="columnFamily">the column family to delete</param>
+        /// <param name="timestamp">timestamp's lower than this will be deleted for the row</param>
+        Task DeleteCellsAsync(string tableName, string rowKey, string columnFamily, long timestamp, RequestOptions options = null);
+
+        /// <summary>
         /// Creates a table and/or fully replaces its schema.
         /// </summary>
         /// <param name="schema">the schema</param>
@@ -245,5 +263,40 @@ namespace Microsoft.HBase.Client
         /// <param name="cells">the cells to insert</param>
         /// <returns>a task that is awaitable, signifying the end of this operation</returns>
         Task StoreCellsAsync(string table, CellSet cells, RequestOptions options = null);
+
+        /// <summary>
+        /// Automically checks if a row/family/qualifier value matches the expected value and updates
+        /// </summary>
+        /// <param name="table">the table</param>
+        /// <param name="row">row to update</param>
+        /// <param name="cellToCheck">cell to check</param>
+        /// <returns>true if the record was updated; false if condition failed at check</returns>
+        Task<bool> CheckAndPutAsync(string table, CellSet.Row row, Cell cellToCheck, RequestOptions options = null);
+
+        /// <summary>
+        /// Automically checks if a row/family/qualifier value matches the expected value and deletes
+        /// </summary>
+        /// <param name="table">the table</param>
+        /// <param name="cellToCheck">cell to check for deleting the row</param>
+        /// <returns>true if the record was deleted; false if condition failed at check</returns>
+        Task<bool> CheckAndDeleteAsync(string table, Cell cellToCheck, RequestOptions options = null);
+
+        /// <summary>
+        /// Automically checks if a row/family/qualifier value matches the expected value and updates
+        /// </summary>
+        /// <param name="table">the table</param>
+        /// <param name="row">row to update</param>
+        /// <param name="cellToCheck">cell to check</param>
+        /// <returns>true if the record was updated; false if condition failed at check</returns>
+        bool CheckAndPut(string table, CellSet.Row row, Cell cellToCheck, RequestOptions options = null);
+
+        /// <summary>
+        /// Automically checks if a row/family/qualifier value matches the expected value and deletes
+        /// </summary>
+        /// <param name="table">the table</param>
+        /// <param name="cellToCheck">cell to check for deleting the row</param>
+        /// <returns>true if the record was deleted; false if condition failed at check</returns>
+        bool CheckAndDelete(string table, Cell cellToCheck, RequestOptions options = null);
+
     }
 }

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -278,8 +278,9 @@ namespace Microsoft.HBase.Client
         /// </summary>
         /// <param name="table">the table</param>
         /// <param name="cellToCheck">cell to check for deleting the row</param>
+        /// <param name="row">row cells to delete</param>
         /// <returns>true if the record was deleted; false if condition failed at check</returns>
-        Task<bool> CheckAndDeleteAsync(string table, Cell cellToCheck, RequestOptions options = null);
+        Task<bool> CheckAndDeleteAsync(string table, Cell cellToCheck, CellSet.Row row = null, RequestOptions options = null);
 
         /// <summary>
         /// Automically checks if a row/family/qualifier value matches the expected value and updates
@@ -295,8 +296,9 @@ namespace Microsoft.HBase.Client
         /// </summary>
         /// <param name="table">the table</param>
         /// <param name="cellToCheck">cell to check for deleting the row</param>
+        /// <param name="row">row cells to delete</param>
         /// <returns>true if the record was deleted; false if condition failed at check</returns>
-        bool CheckAndDelete(string table, Cell cellToCheck, RequestOptions options = null);
+        bool CheckAndDelete(string table, Cell cellToCheck, CellSet.Row row = null, RequestOptions options = null);
 
     }
 }


### PR DESCRIPTION
+ Support for Deleting Cells with a Timestamp provided
+ Support for CheckAndDelete API that can delete other cells based on the Check (Need following Jira code to make full use of it. https://issues.apache.org/jira/browse/HBASE-15323) . 
If the fix is not present, Cellset.Row will be ignored by the server.

+ Unit tests 