### PR TITLE
Use hbaserest0/ as default scan requests endpoint

### DIFF
--- a/Microsoft.HBase.Client.Tests/Clients/HBaseClientTestBase.cs
+++ b/Microsoft.HBase.Client.Tests/Clients/HBaseClientTestBase.cs
@@ -95,10 +95,8 @@ namespace Microsoft.HBase.Client.Tests.Clients
 
             // full range scan
             var scanSettings = new Scanner { batch = 10 };
-            var options = RequestOptions.GetDefaultOptions();
-            options.AlternativeEndpoint = "hbaserest0/";
-            ScannerInformation scannerInfo = await client.CreateScannerAsync(_testTableName, scanSettings, options);
-            await client.DeleteScannerAsync(scannerInfo.TableName, scannerInfo.ScannerId, options);
+            ScannerInformation scannerInfo = await client.CreateScannerAsync(_testTableName, scanSettings);
+            await client.DeleteScannerAsync(scannerInfo.TableName, scannerInfo.ScannerId);
             // TODO add asserts this is actually deleted
         }
 

--- a/Microsoft.HBase.Client/HBaseClient.cs
+++ b/Microsoft.HBase.Client/HBaseClient.cs
@@ -117,7 +117,11 @@ namespace Microsoft.HBase.Client
         {
             tableName.ArgumentNotNullNorEmpty("tableName");
             scannerSettings.ArgumentNotNull("scannerSettings");
-            var optionToUse = options ?? _globalRequestOptions;
+
+            var defaultScanRequestOption = RequestOptions.GetDefaultOptions();
+            defaultScanRequestOption.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            
+            var optionToUse = options ?? defaultScanRequestOption;
             return await optionToUse.RetryPolicy.ExecuteAsync(() => CreateScannerAsyncInternal(tableName, scannerSettings, optionToUse));
         }
 
@@ -163,7 +167,10 @@ namespace Microsoft.HBase.Client
             tableName.ArgumentNotNullNorEmpty("tableName");
             scannerId.ArgumentNotNullNorEmpty("scannerId");
 
-            var optionToUse = options ?? _globalRequestOptions;
+            var defaultScanRequestOption = RequestOptions.GetDefaultOptions();
+            defaultScanRequestOption.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+
+            var optionToUse = options ?? defaultScanRequestOption;
             return optionToUse.RetryPolicy.ExecuteAsync(() => DeleteScannerAsyncInternal(tableName, scannerId, optionToUse));
         }
 
@@ -537,7 +544,11 @@ namespace Microsoft.HBase.Client
         public async Task<CellSet> ScannerGetNextAsync(ScannerInformation scannerInfo, RequestOptions options = null)
         {
             scannerInfo.ArgumentNotNull("scannerInfo");
-            var optionToUse = options ?? _globalRequestOptions;
+
+            var defaultScanRequestOption = RequestOptions.GetDefaultOptions();
+            defaultScanRequestOption.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+
+            var optionToUse = options ?? defaultScanRequestOption;
             return await optionToUse.RetryPolicy.ExecuteAsync(() => ScannerGetNextAsyncInternal(scannerInfo, optionToUse));
         }
 


### PR DESCRIPTION
If the endpoint is not specified, scan requests will always send to
hbaserest0/, which is the REST server on workernode0.