### PR TITLE
Users must provide RequestOption in all scan requests

### DIFF
--- a/Microsoft.HBase.Client.Tests/Clients/VNetClientTest.cs
+++ b/Microsoft.HBase.Client.Tests/Clients/VNetClientTest.cs
@@ -19,8 +19,9 @@ namespace Microsoft.HBase.Client.Tests.Clients
     using Microsoft.HBase.Client.LoadBalancing;
     using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.HBase.Client.Tests.Utilities;
 
-    //    [TestClass]
+    //[TestClass]
     public class VNetClientTest : HBaseClientTestBase
     {
         public override IHBaseClient CreateClient()
@@ -38,6 +39,31 @@ namespace Microsoft.HBase.Client.Tests.Clients
             options.AlternativeEndpoint = "/";
 
             return new HBaseClient(null, options, new LoadBalancerRoundRobin(regionServerHostNames));
+        }
+
+        //[TestMethod]
+        //[TestCategory(TestRunMode.CheckIn)]
+        public override void TestFullScan()
+        {
+        }
+
+        //[TestMethod]
+        //[TestCategory(TestRunMode.CheckIn)]
+        public override void TestScannerCreation()
+        {
+        }
+
+        //[TestMethod]
+        //[TestCategory(TestRunMode.CheckIn)]
+        //[ExpectedException(typeof(System.AggregateException), "The remote server returned an error: (404) Not Found.")]
+        public override void TestScannerDeletion()
+        {
+        }
+
+        //[TestMethod]
+        //[TestCategory(TestRunMode.CheckIn)]
+        public override void TestSubsetScan()
+        {
         }
     }
 }

--- a/Microsoft.HBase.Client.Tests/FilterTests.cs
+++ b/Microsoft.HBase.Client.Tests/FilterTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.HBase.Client.Tests
     using Microsoft.HBase.Client.Tests.Utilities;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using org.apache.hadoop.hbase.rest.protobuf.generated;
+    using Microsoft.HBase.Client.LoadBalancing;
 
     // ReSharper disable InconsistentNaming
 
@@ -80,11 +81,23 @@ namespace Microsoft.HBase.Client.Tests
         {
             var client = new HBaseClient(_credentials);
             var scan = new Scanner();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scan, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
+                actualRecords.ShouldContainOnly(_allExpectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scan);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(_allExpectedRecords);
         }
 
         [TestMethod]
@@ -98,11 +111,23 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new ColumnCountGetFilter(2);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -116,11 +141,23 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new ColumnPaginationFilter(1, 1);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -133,11 +170,23 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new ColumnPrefixFilter(Encoding.UTF8.GetBytes(LineNumberColumnName));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -150,11 +199,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new ColumnRangeFilter(Encoding.UTF8.GetBytes(ColumnNameA), true, Encoding.UTF8.GetBytes(ColumnNameB), false);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -172,11 +234,23 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.Equal,
                 new BinaryComparator(BitConverter.GetBytes(1)));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -190,11 +264,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new FamilyFilter(CompareFilter.CompareOp.Equal, new BinaryComparator(Encoding.UTF8.GetBytes(ColumnFamilyName1)));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -220,11 +307,24 @@ namespace Microsoft.HBase.Client.Tests
 
             var filter = new FilterList(FilterList.Operator.MustPassAll, f0, f1);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -250,11 +350,24 @@ namespace Microsoft.HBase.Client.Tests
 
             var filter = new FilterList(FilterList.Operator.MustPassOne, f0, f1);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -269,11 +382,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new KeyOnlyFilter();
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
 
@@ -290,11 +416,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new InclusiveStopFilter(rawRowKey);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
 
@@ -310,11 +449,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new KeyOnlyFilter();
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -330,11 +482,23 @@ namespace Microsoft.HBase.Client.Tests
             var prefixes = new List<byte[]> { Encoding.UTF8.GetBytes(ColumnNameA), Encoding.UTF8.GetBytes(ColumnNameB) };
             var filter = new MultipleColumnPrefixFilter(prefixes);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -345,11 +509,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new PageFilter(2);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner,scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.Count.ShouldBeGreaterThanOrEqualTo(2);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.Count.ShouldBeGreaterThanOrEqualTo(2);
         }
 
         [TestMethod]
@@ -372,11 +549,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new PrefixFilter(prefix);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -389,11 +579,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new QualifierFilter(CompareFilter.CompareOp.Equal, new BinaryComparator(Encoding.UTF8.GetBytes(LineNumberColumnName)));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -406,11 +609,24 @@ namespace Microsoft.HBase.Client.Tests
             // set this large enough so that we get all records back
             var filter = new RandomRowFilter(2000.0F);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(_allExpectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(_allExpectedRecords);
         }
 
         [TestMethod]
@@ -425,11 +641,24 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new RowFilter(CompareFilter.CompareOp.Equal, new BinaryComparator(Encoding.UTF8.GetBytes(example.RowKey)));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -450,11 +679,24 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.Equal,
                 Encoding.UTF8.GetBytes(bValue));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -474,11 +716,23 @@ namespace Microsoft.HBase.Client.Tests
                 filterIfMissing: true);
 
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -496,11 +750,24 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.GreaterThan,
                 BitConverter.GetBytes(1));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -519,11 +786,23 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.GreaterThanOrEqualTo,
                 BitConverter.GetBytes(1));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -541,11 +820,23 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.LessThan,
                 BitConverter.GetBytes(1));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -564,11 +855,24 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.LessThanOrEqualTo,
                 BitConverter.GetBytes(1));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -586,11 +890,23 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.NoOperation,
                 BitConverter.GetBytes(1));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
 
@@ -608,11 +924,24 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.NotEqual,
                 BitConverter.GetBytes(1));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -633,11 +962,23 @@ namespace Microsoft.HBase.Client.Tests
                 comparer,
                 filterIfMissing: false);
             scanner.filter = filter.ToEncodedString();
-           
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -658,11 +999,24 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.Equal,
                 comparer);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
 
-            actualRecords.ShouldContainOnly(expectedRecords);
         }
 
         [TestMethod]
@@ -682,11 +1036,23 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.Equal,
                 comparer);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -710,11 +1076,23 @@ namespace Microsoft.HBase.Client.Tests
                 CompareFilter.CompareOp.Equal,
                 comparer);
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -727,11 +1105,23 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new SkipFilter(new ValueFilter(CompareFilter.CompareOp.NotEqual, new BinaryComparator(BitConverter.GetBytes(0))));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -743,18 +1133,44 @@ namespace Microsoft.HBase.Client.Tests
             // scan all and retrieve timestamps
             var client = new HBaseClient(_credentials);
             var scanner = new Scanner();
-            ScannerInformation scanAll = client.CreateScanner(_tableName, scanner);
-            List<long> timestamps = RetrieveTimestamps(scanAll).ToList();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanAll = null;
+            List<long> timestamps = null;
+            try
+            {
+                scanAll = client.CreateScanner(_tableName, scanner, scanOptions);
+                timestamps = RetrieveTimestamps(scanAll, scanOptions).ToList();
+            }
+            finally
+            {
+                if (scanAll != null)
+                {
+                    client.DeleteScanner(_tableName, scanAll, scanOptions);
+                }
+            }
+
+            Assert.IsNotNull(timestamps);
 
             // timestamps scan
             scanner = new Scanner();
             var filter = new TimestampsFilter(timestamps);
             scanner.filter = filter.ToEncodedString();
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -768,11 +1184,23 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new ValueFilter(CompareFilter.CompareOp.Equal, new BinaryComparator(BitConverter.GetBytes(3)));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -784,11 +1212,23 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new ValueFilter(CompareFilter.CompareOp.Equal, new RegexStringComparator(".*"));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
         [TestMethod]
@@ -801,21 +1241,33 @@ namespace Microsoft.HBase.Client.Tests
             var scanner = new Scanner();
             var filter = new WhileMatchFilter(new ValueFilter(CompareFilter.CompareOp.NotEqual, new BinaryComparator(BitConverter.GetBytes(0))));
             scanner.filter = filter.ToEncodedString();
+            RequestOptions scanOptions = RequestOptions.GetDefaultOptions();
+            scanOptions.AlternativeEndpoint = Constants.RestEndpointBaseZero;
+            ScannerInformation scanInfo = null;
+            try
+            {
+                scanInfo = client.CreateScanner(_tableName, scanner, scanOptions);
+                List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo, scanOptions).ToList();
 
-            ScannerInformation scanInfo = client.CreateScanner(_tableName, scanner);
-            List<FilterTestRecord> actualRecords = RetrieveResults(scanInfo).ToList();
-
-            actualRecords.ShouldContainOnly(expectedRecords);
+                actualRecords.ShouldContainOnly(expectedRecords);
+            }
+            finally
+            {
+                if (scanInfo != null)
+                {
+                    client.DeleteScanner(_tableName, scanInfo, scanOptions);
+                }
+            }
         }
 
-        private IEnumerable<long> RetrieveTimestamps(ScannerInformation scanInfo)
+        private IEnumerable<long> RetrieveTimestamps(ScannerInformation scanInfo, RequestOptions scanOptions)
         {
             var rv = new HashSet<long>();
 
             var client = new HBaseClient(_credentials);
             CellSet next;
 
-            while ((next = client.ScannerGetNext(scanInfo)) != null)
+            while ((next = client.ScannerGetNext(scanInfo, scanOptions)) != null)
             {
                 foreach (CellSet.Row row in next.rows)
                 {
@@ -830,14 +1282,14 @@ namespace Microsoft.HBase.Client.Tests
             return rv;
         }
 
-        private IEnumerable<FilterTestRecord> RetrieveResults(ScannerInformation scanInfo)
+        private IEnumerable<FilterTestRecord> RetrieveResults(ScannerInformation scanInfo, RequestOptions scanOptions)
         {
             var rv = new List<FilterTestRecord>();
 
             var client = new HBaseClient(_credentials);
             CellSet next;
 
-            while ((next = client.ScannerGetNext(scanInfo)) != null)
+            while ((next = client.ScannerGetNext(scanInfo, scanOptions)) != null)
             {
                 foreach (CellSet.Row row in next.rows)
                 {

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -22,7 +22,7 @@ namespace Microsoft.HBase.Client
     /// A C# connector to HBase. 
     /// </summary>
     /// <remarks>
-    /// It currently targets HBase 0.98 and HDInsight 3.1 on Microsoft Azure.
+    /// It currently targets HBase 0.98.4 and HDInsight 3.2 on Microsoft Azure.
     /// The communication works through HBase REST (StarGate) which uses ProtoBuf as a serialization format.
     /// 
     /// The usage is quite simple:
@@ -34,6 +34,10 @@ namespace Microsoft.HBase.Client
     /// 
     /// Console.WriteLine(version);
     /// </code>
+    /// 
+    /// Scan Requests are stateful. Please provide RequestOption for every scan requests to specify the request is sent to which REST server.
+    /// In Gateway mode, RequestOption.AlternativeEndpoint need to be set to "hbaserest0/","hbaserest1/","hbaserest2/"...etc.
+    /// In VNET mode,  RequestOption.AlternativeEndpoint need to be set to "/" and RequestOption.AlternativeHost need to be set or use loadbalancer.
     /// </remarks>
     public interface IHBaseClient
     {
@@ -43,8 +47,9 @@ namespace Microsoft.HBase.Client
         /// </summary>
         /// <param name="tableName">the table to scan</param>
         /// <param name="scannerSettings">the settings to e.g. set the batch size of this scan</param>
+        /// <param name="options">the request options, scan requests must set endpoint(Gateway mode) or host(VNET mode) to receive the scan request</param>
         /// <returns>A ScannerInformation which contains the continuation url/token and the table name</returns>
-        ScannerInformation CreateScanner(string tableName, Scanner scannerSettings, RequestOptions options = null);
+        ScannerInformation CreateScanner(string tableName, Scanner scannerSettings, RequestOptions options);
 
         /// <summary>
         /// Creates a scanner on the server side.
@@ -52,22 +57,25 @@ namespace Microsoft.HBase.Client
         /// </summary>
         /// <param name="tableName">the table to scan</param>
         /// <param name="scannerSettings">the settings to e.g. set the batch size of this scan</param>
+        /// <param name="options">the request options, scan requests must set endpoint(Gateway mode) or host(VNET mode) to receive the scan request</param>
         /// <returns>A ScannerInformation which contains the continuation url/token and the table name</returns>
-        Task<ScannerInformation> CreateScannerAsync(string tableName, Scanner scannerSettings, RequestOptions options = null);
+        Task<ScannerInformation> CreateScannerAsync(string tableName, Scanner scannerSettings, RequestOptions options);
 
         /// <summary>
         /// Deletes scanner.        
         /// </summary>
         /// <param name="tableName">the table the scanner is associated with.</param>
-        /// <param name="scannerId">the id of the scanner to delete.</param>
-        void DeleteScanner(string tableName, string scannerId, RequestOptions options = null);
+        /// <param name="scannerInfo">the scanner information retrieved by #CreateScanner()</param>
+        /// <param name="options">the request options, scan requests must set endpoint(Gateway mode) or host(VNET mode) to receive the scan request</param>
+        void DeleteScanner(string tableName, ScannerInformation scannerInfo, RequestOptions options);
 
         /// <summary>
         /// Deletes scanner.        
         /// </summary>
         /// <param name="tableName">the table the scanner is associated with.</param>
-        /// <param name="scannerId">the id of the scanner to delete.</param>
-        Task DeleteScannerAsync(string tableName, string scannerId, RequestOptions options = null);
+        /// <param name="scannerInfo">the scanner information retrieved by #CreateScanner()</param>
+        /// <param name="options">the request options, scan requests must set endpoint(Gateway mode) or host(VNET mode) to receive the scan request</param>
+        Task DeleteScannerAsync(string tableName, ScannerInformation scannerInfo, RequestOptions options);
 
         /// <summary>
         /// Deletes row with specific row key.        
@@ -239,15 +247,17 @@ namespace Microsoft.HBase.Client
         /// Scans the next set of messages.
         /// </summary>
         /// <param name="scannerInfo">the scanner information retrieved by #CreateScanner()</param>
+        /// <param name="options">the request options, scan requests must set endpoint(Gateway mode) or host(VNET mode) to receive the scan request</param>
         /// <returns>a cellset, or null if the scanner is exhausted</returns>
-        CellSet ScannerGetNext(ScannerInformation scannerInfo, RequestOptions options = null);
+        CellSet ScannerGetNext(ScannerInformation scannerInfo, RequestOptions options);
 
         /// <summary>
         /// Scans the next set of messages.
         /// </summary>
         /// <param name="scannerInfo">the scanner information retrieved by #CreateScanner()</param>
+        /// <param name="options">the request options, scan requests must set endpoint(Gateway mode) or host(VNET mode) to receive the scan request</param>
         /// <returns>a cellset, or null if the scanner is exhausted</returns>
-        Task<CellSet> ScannerGetNextAsync(ScannerInformation scannerInfo, RequestOptions options = null);
+        Task<CellSet> ScannerGetNextAsync(ScannerInformation scannerInfo, RequestOptions options);
 
         /// <summary>
         /// Stores the given cells in the supplied table.


### PR DESCRIPTION
Current SDK supports stateful scanner only. Previously all scan requests
are sent to REST server 0 by default. This change will let users decide
which server to send requests. It is the same as the previous version if
users use hbaserest0/ as the alternative endpoint. See test code for
examples.