### PR TITLE
Implement IDisposable on HBaseClient to dispose of ClusterCredentials correctly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,9 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+#Roslyn caches
+.vs/
+
+#GhostDoc files
+*.sln.GhostDoc.xml

--- a/Microsoft.HBase.Client/Requester/GatewayWebRequester.cs
+++ b/Microsoft.HBase.Client/Requester/GatewayWebRequester.cs
@@ -25,11 +25,16 @@ namespace Microsoft.HBase.Client.Requester
     /// <summary>
     /// 
     /// </summary>
-    public sealed class GatewayWebRequester : IWebRequester
+    public sealed class GatewayWebRequester : IWebRequester, IDisposable
     {
         private readonly string _contentType;
         private readonly CredentialCache _credentialCache;
-        private readonly ClusterCredentials _credentials;
+        private ClusterCredentials _credentials;
+
+        /// <summary>
+        /// Used to detect redundant calls to <see cref="IDisposable.Dispose"/>.
+        /// </summary>
+        private bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GatewayWebRequester"/> class.
@@ -126,6 +131,28 @@ namespace Microsoft.HBase.Client.Requester
         private void InitCache()
         {
             _credentialCache.Add(_credentials.ClusterUri, "Basic", new NetworkCredential(_credentials.UserName, _credentials.ClusterPassword));
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting
+        /// unmanaged resources.
+        /// </summary>
+        /// <remarks>
+        /// Since this class is <see langword="sealed"/>, the standard <see
+        /// cref="IDisposable.Dispose"/> pattern is not required. Also, <see
+        /// cref="GC.SuppressFinalize"/> is not needed.
+        /// </remarks>
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                if (_credentials != null)
+                {
+                    _credentials.Dispose();
+                    _credentials = null;
+                }
+                _disposed = true;
+            }
         }
     }
 }

--- a/Microsoft.HBase.Client/Requester/IWebRequester.cs
+++ b/Microsoft.HBase.Client/Requester/IWebRequester.cs
@@ -33,13 +33,46 @@ namespace Microsoft.HBase.Client.Requester
         public TimeSpan RequestLatency { get; set; }
         public Action<Response> PostRequestAction { get; set; }
 
+        /// <summary>
+        /// Used to detect redundant calls to <see cref="IDisposable.Dispose"/>.
+        /// </summary>
+        private bool _isDisposed; // To detect redundant calls
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// <see langword="true"/> to release both managed and unmanaged resources; <see
+        /// langword="false"/> to release only unmanaged resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    if (PostRequestAction != null)
+                    {
+                        PostRequestAction(this);
+                        PostRequestAction = null;
+                    }
+                    WebResponse.Dispose();
+                    WebResponse = null;
+                }
+                _isDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting
+        /// unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
-            if (PostRequestAction != null)
-            {
-                PostRequestAction(this);
-            }
-            WebResponse.Dispose();
+            Dispose(true);
+            // Since this class is not sealed, derived classes may introduce unmanaged resources, so
+            // suppress Finalize calls if the instance has been disposed.
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
1. Add `IDisposable` implementation to `GatewayWebRequester` to dispose of its `ClusterCredentials` member variable.
2. Add `IDisposable` implementation to `HBaseClient` which disposes of the `IWebRequest` member variable if it is an `IDisposable`, which it will be if it is an `GatewayWebRequester`.
3. Implement the standard `IDisposable` pattern in `Microsoft.HBase.Client.Requester.Response` since it is not a sealed class.
4. Fix spelling of 'atomically' in HBaseClient.cs comments.
5. Add .gitignore exclusions for Roslyn caches. (.vs/)
6. Add .gitignore exclusions for GhostDoc files. (*.sln.GhostDoc.xml)
7. Suppress false positive Code Analysis error *CA2000:Dispose objects before losing scope* on `HBaseClient(ClusterCredentials credentials, RequestOptions globalRequestOptions = null, ILoadBalancer loadBalancer = null)`