### PR TITLE
Add stateless scanner API for VNET mode

### DIFF
--- a/Microsoft.HBase.Client.Tests/Clients/GatewayClientTest.cs
+++ b/Microsoft.HBase.Client.Tests/Clients/GatewayClientTest.cs
@@ -23,7 +23,6 @@ namespace Microsoft.HBase.Client.Tests.Clients
     using System.Collections.Generic;
     using System.Linq;
     using System;
-    using System.Threading.Tasks;
 
     [TestClass]
     public class GatewayClientTest : HBaseClientTestBase
@@ -79,7 +78,7 @@ namespace Microsoft.HBase.Client.Tests.Clients
 
         [TestMethod]
         [TestCategory(TestRunMode.CheckIn)]
-        public override void TestScannerCreation()
+        public void TestScannerCreation()
         {
             var client = CreateClient();
             var scanSettings = new Scanner { batch = 2 };
@@ -107,7 +106,7 @@ namespace Microsoft.HBase.Client.Tests.Clients
         [TestMethod]
         [TestCategory(TestRunMode.CheckIn)]
         [ExpectedException(typeof(System.AggregateException), "The remote server returned an error: (404) Not Found.")]
-        public override void TestScannerDeletion()
+        public void TestScannerDeletion()
         {
             var client = CreateClient();
 

--- a/Microsoft.HBase.Client.Tests/Clients/HBaseClientTestBase.cs
+++ b/Microsoft.HBase.Client.Tests/Clients/HBaseClientTestBase.cs
@@ -68,11 +68,6 @@ namespace Microsoft.HBase.Client.Tests.Clients
         [TestMethod]
         [TestCategory(TestRunMode.CheckIn)]
         [ExpectedException(typeof(System.AggregateException), "The remote server returned an error: (404) Not Found.")]
-        public abstract void TestScannerDeletion();
-
-        [TestMethod]
-        [TestCategory(TestRunMode.CheckIn)]
-        [ExpectedException(typeof(System.AggregateException), "The remote server returned an error: (404) Not Found.")]
         public void TestCellsDeletion()
         {
             const string testKey = "content";
@@ -136,10 +131,6 @@ namespace Microsoft.HBase.Client.Tests.Clients
 
         [TestMethod]
         [TestCategory(TestRunMode.CheckIn)]
-        public abstract void TestScannerCreation();
-
-        [TestMethod]
-        [TestCategory(TestRunMode.CheckIn)]
         public void TestStoreSingleCell()
         {
             const string testKey = "content";
@@ -175,7 +166,7 @@ namespace Microsoft.HBase.Client.Tests.Clients
             Assert.AreEqual(_testTableSchema.columns[0].name, schema.columns[0].name);
         }
 
-        public void StoreTestData(IHBaseClient hBaseClient)
+        public void StoreTestData(IHBaseClient hbaseClient)
         {
             // we are going to insert the keys 0 to 100 and then do some range queries on that
             const string testValue = "the force is strong in this column";
@@ -188,7 +179,7 @@ namespace Microsoft.HBase.Client.Tests.Clients
                 set.rows.Add(row);
             }
 
-            hBaseClient.StoreCellsAsync(testTableName, set).Wait();
+            hbaseClient.StoreCellsAsync(testTableName, set).Wait();
         }
     }
 }

--- a/Microsoft.HBase.Client.Tests/Clients/VNetClientTest.cs
+++ b/Microsoft.HBase.Client.Tests/Clients/VNetClientTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.HBase.Client.Tests.Clients
 
             StoreTestData(client);
             var expectedSet = new HashSet<int>(Enumerable.Range(0, 100));
-            List<CellSet> cells = client.StatelessScannerAsync(testTableName).Result;
+            IEnumerable<CellSet> cells = client.StatelessScannerAsync(testTableName).Result;
             foreach (CellSet cell in cells)
             {
                 foreach (CellSet.Row row in cell.rows)
@@ -71,7 +71,7 @@ namespace Microsoft.HBase.Client.Tests.Clients
             StoreTestData(client);
             var expectedSet = new HashSet<int>(Enumerable.Range(startRow, endRow - startRow));
             // TODO how to change rowkey to internal hbase binary string
-            List<CellSet> cells = client.StatelessScannerAsync(testTableName, "", "startrow=\x0A\x00\x00\x00&endrow=\x0F\x00\x00\x00").Result;
+            IEnumerable<CellSet> cells = client.StatelessScannerAsync(testTableName, "", "startrow=\x0A\x00\x00\x00&endrow=\x0F\x00\x00\x00").Result;
 
             foreach (CellSet cell in cells)
             {

--- a/Microsoft.HBase.Client/HBaseClient.cs
+++ b/Microsoft.HBase.Client/HBaseClient.cs
@@ -27,6 +27,8 @@ namespace Microsoft.HBase.Client
     using org.apache.hadoop.hbase.rest.protobuf.generated;
     using ProtoBuf;
     using System.Globalization;
+    using System.Collections.Generic;
+
     /// <summary>
     /// A C# connector to HBase. 
     /// </summary>
@@ -420,7 +422,7 @@ namespace Microsoft.HBase.Client
 
         private async Task<CellSet> ScannerGetNextAsyncInternal(ScannerInformation scannerInfo, RequestOptions options)
         {
-            using (Response webResponse = await GetRequestAsync(scannerInfo.TableName + "/scanner/" + scannerInfo.ScannerId, options))
+            using (Response webResponse = await GetRequestAsync(scannerInfo.TableName + "/scanner/" + scannerInfo.ScannerId, null, options))
             {
                 if (webResponse.WebResponse.StatusCode == HttpStatusCode.OK)
                 {
@@ -429,6 +431,52 @@ namespace Microsoft.HBase.Client
 
                 return null;
             }
+        }
+
+        public async Task<List<CellSet>> StatelessScannerAsync(string tableName, string optionalRowPrefix = null, string scanParameters = null, RequestOptions options = null)
+        {
+            tableName.ArgumentNotNullNorEmpty("tableName");
+            var optionToUse = options ?? _globalRequestOptions;
+            var rowPrefix = optionalRowPrefix ?? string.Empty;
+            return await optionToUse.RetryPolicy.ExecuteAsync(() => StatelessScannerAsyncInternal(tableName, optionalRowPrefix, scanParameters, optionToUse));
+        }
+
+        private async Task<List<CellSet>> StatelessScannerAsyncInternal(string tableName, string optionalRowPrefix, string scanParameters, RequestOptions options)
+        {
+            using (Response webResponse = await GetRequestAsync(tableName + "/" + optionalRowPrefix + "*", scanParameters, options))
+            {
+                if (webResponse.WebResponse.StatusCode == HttpStatusCode.OK)
+                {
+                    return readProtobufStream(webResponse.WebResponse.GetResponseStream());
+                }
+
+                return null;
+            }
+        }
+
+        private List<CellSet> readProtobufStream(Stream stream)
+        {
+            List<CellSet> cells = new List<CellSet>();
+            var reader = new BinaryReader(stream);
+            while (true)
+            {
+                // read chunck length
+                byte[] lengthBytes = new byte[2];
+                int readBytes = reader.Read(lengthBytes, 0, lengthBytes.Length);
+                if (readBytes <= 0)
+                {
+                    break;
+                }
+                sbyte[] slengthBytes = new sbyte[2];
+                Buffer.BlockCopy(lengthBytes, 0, slengthBytes, 0, lengthBytes.Length);
+                int length = (short)(((slengthBytes[0] & 0xFF) << 8) | (slengthBytes[1] & 0xFF));
+                byte[] cellSet = new byte[length];
+                stream.Read(cellSet, 0, length);
+                CellSet sc = Serializer.Deserialize<CellSet>(new MemoryStream(cellSet));
+                cells.Add(sc);
+            }
+
+            return cells;
         }
 
         /// <summary>
@@ -448,7 +496,7 @@ namespace Microsoft.HBase.Client
             var optionToUse = options ?? _globalRequestOptions;
 
             return await optionToUse.RetryPolicy.ExecuteAsync<bool>(() => StoreCellsAsyncInternal(table, cellSet, optionToUse, Encoding.UTF8.GetString(row.key), CheckAndPutQuery));
-           
+
         }
 
         /// <summary>
@@ -478,7 +526,7 @@ namespace Microsoft.HBase.Client
             var optionToUse = options ?? _globalRequestOptions;
 
             return await optionToUse.RetryPolicy.ExecuteAsync<bool>(() => StoreCellsAsyncInternal(table, cellSet, optionToUse, Encoding.UTF8.GetString(row.key), CheckAndDeleteQuery));
-           
+
         }
 
         /// <summary>
@@ -502,7 +550,7 @@ namespace Microsoft.HBase.Client
             // note the fake row key to insert a set of cells
             using (Response webResponse = await PutRequestAsync(path, query, cells, options))
             {
-                if(webResponse.WebResponse.StatusCode == HttpStatusCode.NotModified)
+                if (webResponse.WebResponse.StatusCode == HttpStatusCode.NotModified)
                 {
                     return false;
                 }
@@ -561,11 +609,11 @@ namespace Microsoft.HBase.Client
             }
         }
 
-        private async Task<Response> GetRequestAsync(string endpoint, RequestOptions options)
+        private async Task<Response> GetRequestAsync(string endpoint, string query, RequestOptions options)
         {
             options.ArgumentNotNull("request options");
             endpoint.ArgumentNotNull("endpoint");
-            return await _requester.IssueWebRequestAsync(endpoint, null, "GET", null, options);
+            return await _requester.IssueWebRequestAsync(endpoint, query, "GET", null, options);
         }
 
         private async Task<Response> PostRequestAsync<TReq>(string endpoint, TReq request, RequestOptions options)

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -17,7 +17,7 @@ namespace Microsoft.HBase.Client
 {
     using System.Threading.Tasks;
     using org.apache.hadoop.hbase.rest.protobuf.generated;
-
+    using System.Collections.Generic;
     /// <summary>
     /// A C# connector to HBase. 
     /// </summary>
@@ -175,5 +175,8 @@ namespace Microsoft.HBase.Client
         /// <param name="row">row cells to delete</param>
         /// <returns>true if the record was deleted; false if condition failed at check</returns>
         Task<bool> CheckAndDeleteAsync(string table, Cell cellToCheck, CellSet.Row row = null, RequestOptions options = null);
+
+
+        Task<List<CellSet>> StatelessScannerAsync(string tableName, string optionalRowPrefix = null, string scanParameters = null, RequestOptions options = null);
     }
 }

--- a/Microsoft.HBase.Client/IHBaseClient.cs
+++ b/Microsoft.HBase.Client/IHBaseClient.cs
@@ -177,6 +177,6 @@ namespace Microsoft.HBase.Client
         Task<bool> CheckAndDeleteAsync(string table, Cell cellToCheck, CellSet.Row row = null, RequestOptions options = null);
 
 
-        Task<List<CellSet>> StatelessScannerAsync(string tableName, string optionalRowPrefix = null, string scanParameters = null, RequestOptions options = null);
+        Task<IEnumerable<CellSet>> StatelessScannerAsync(string tableName, string optionalRowPrefix = null, string scanParameters = null, RequestOptions options = null);
     }
 }


### PR DESCRIPTION
https://hbase.apache.org/apidocs/org/apache/hadoop/hbase/rest/package-summary.html#operation_stateless_scanner
refer to VNETClientTest.cs for examples, filter syntax is the same as the one used in thrift, typical usages:
1. List<CellSet> cells = client.StatelessScannerAsync("tableX","", "filter=PrefixFilter(\'row_prefix\')").Result;
2. List<CellSet> cells = client.StatelessScannerAsync("tableX","row_prefix", "startrow=row_prefix_1&limit=1").Result;

